### PR TITLE
Demo how tape can be used to retry tasks

### DIFF
--- a/tape-sample/res/values/strings.xml
+++ b/tape-sample/res/values/strings.xml
@@ -7,4 +7,5 @@
   <string name="status">%s uploads pending.</string>
   <string name="task_added">Added new upload task.</string>
   <string name="task_completed">An upload task completed.</string>
+  <string name="task_failed">Upload task failed after %d retries</string>
 </resources>

--- a/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadFailureEvent.java
+++ b/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadFailureEvent.java
@@ -1,0 +1,10 @@
+// Copyright 2012 Square, Inc.
+package com.squareup.tape.sample;
+
+public class ImageUploadFailureEvent {
+  public final int numRetries;
+
+  public ImageUploadFailureEvent(int numRetries) {
+    this.numRetries = numRetries;
+  }
+}

--- a/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadSuccessEvent.java
+++ b/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadSuccessEvent.java
@@ -3,8 +3,10 @@ package com.squareup.tape.sample;
 
 public class ImageUploadSuccessEvent {
   public final String url;
+  public final int numRetries;
 
-  public ImageUploadSuccessEvent(String url) {
+  public ImageUploadSuccessEvent(String url, int numRetries) {
     this.url = url;
+    this.numRetries = numRetries;
   }
 }

--- a/tape-sample/src/main/java/com/squareup/tape/sample/SampleActivity.java
+++ b/tape-sample/src/main/java/com/squareup/tape/sample/SampleActivity.java
@@ -77,7 +77,13 @@ public class SampleActivity extends Activity {
   @SuppressWarnings("UnusedDeclaration") // Used by event bus.
   @Subscribe public void onUploadSuccess(ImageUploadSuccessEvent event) {
     Toast.makeText(this, R.string.task_completed, LENGTH_SHORT).show();
-    uploads.add(event.url);
+    uploads.add(String.format("%s (%d retries)", event.url, event.numRetries));
+  }
+
+  @SuppressWarnings("UnusedDeclaration") // Used by event bus.
+  @Subscribe public void onUploadFailure(ImageUploadFailureEvent event) {
+    Toast.makeText(this, getString(R.string.task_failed, event.numRetries),
+            LENGTH_SHORT).show();
   }
 
   @Override protected void onResume() {


### PR DESCRIPTION
Update tape-sample with some basic retry functionality to demonstrate a
common use case for the library.

I have updated the onFailure callback method a little to retry the last task.
To simulate some random failures I've fudged the API key randomly before making
the post to imgur.

The number of retries are then shown back in the main activity alongside the
image URL.