### PR TITLE
Changes QueueFile#ringRead to use the offset parameter in all cases

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -247,7 +247,7 @@ public class QueueFile {
     position = wrapPosition(position);
     if (position + count <= fileLength) {
       raf.seek(position);
-      raf.readFully(buffer, 0, count);
+      raf.readFully(buffer, offset, count);
     } else {
       // The read overlaps the EOF.
       // # of bytes to read before the EOF.

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -297,6 +297,27 @@ public class QueueFileTest {
     assertThat(queueFile.peek()).isEqualTo(a);
     assertThat(iteration[0]).isEqualTo(2);
   }
+  
+  @Test public void testForEachReadWithOffset() throws IOException {
+      QueueFile queueFile = new QueueFile(file);
+
+      queueFile.add(new byte[] {1, 2});
+      queueFile.add(new byte[] {3, 4, 5});
+      
+      final byte[] actual = new byte[5];
+      final int[] offset = new int[] {0};
+
+      QueueFile.ElementReader elementReader = new QueueFile.ElementReader() {
+        @Override public void read(InputStream in, int length) throws IOException {  
+          in.read(actual, offset[0], length);
+          offset[0] += length;
+        }
+      };
+
+      queueFile.forEach(elementReader);
+
+      assertThat(actual).isEqualTo(new byte[] {1, 2, 3, 4, 5});
+    }
 
   /**
    * Exercise a bug where wrapped elements were getting corrupted when the


### PR DESCRIPTION
When trying to use `forEach` and an `ElementReader` to read data into offset positions of a single byte array, I noticed that the bytes starting at offset 0 would be repeatedly overwritten, rather than subsequent elements' data being read into the expected offsets of my byte array.

I believe the culprit is the use of the constant offset `0` in the first branch of the conditional logic in `QueueFile#ringRead`. I've included a test that should fail against the current logic in master, and pass with my changes.

Thanks for your time and consideration!
