### PR TITLE
Fix sample to match Gson requirements

### DIFF
--- a/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadTask.java
+++ b/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadTask.java
@@ -34,6 +34,11 @@ public class ImageUploadTask implements Task<ImageUploadTask.Callback> {
     this.file = file;
   }
 
+  // Gson needs a no-args constructor
+  private ImageUploadTask() {
+    this(null);
+  }
+
   @Override public void execute(final Callback callback) {
     // Image uploading is slow. Execute HTTP POST on a background thread.
     new Thread(new Runnable() {


### PR DESCRIPTION
AFAIK, Gson requires serialized classes to have a no-args constructor. Added one to `ImageUploadTask`, to remind anyone checking the samples.
