### PR TITLE
Don't include 'v' in the download button label

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -152,7 +152,7 @@ limitations under the License.</p>
           // Replace in Maven <dependency>
           $('#mvn-version').text(data[0].name);
           // Replace in download button
-          $('#download-btn').text('Download v' + data[0].name);
+          $('#download-btn').text('Download ' + data[0].name);
       });
     </script>
   </body>


### PR DESCRIPTION
The package name is included before the version name, which makes
the 'v' look a little wonky.
