### PR TITLE
Prevent corruption when expanding a perfectly saturated queue

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -375,7 +375,7 @@ public class QueueFile {
     int endOfLastElement = wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
 
     // If the buffer is split, we need to make it contiguous
-    if (endOfLastElement < first.position) {
+    if (endOfLastElement <= first.position) {
       FileChannel channel = raf.getChannel();
       channel.position(fileLength); // destination position
       int count = endOfLastElement - Element.HEADER_LENGTH;

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -571,6 +571,50 @@ public class QueueFileTest {
   }
 
   /**
+   * Exercise a bug where an expanding queue file where the start and end positions
+   * are the same causes corruption.
+   */
+  @Test public void testSaturatedFileExpansionMovesElements() throws IOException {
+    QueueFile queue = new QueueFile(file);
+
+    // Create test data - 1016-byte blocks marked consecutively 1, 2, 3, 4, 5 and 6,
+    // four of which perfectly fill the queue file, taking into account the file header
+    // and the item headers.
+    // Each item is of length
+    // (QueueFile.INITIAL_LENGTH - QueueFile.HEADER_LENGTH) / 4 - element_header_length
+    // = 1016 bytes
+    byte[][] values = new byte[6][];
+    for (int blockNum = 0; blockNum < values.length; blockNum++) {
+      values[blockNum] = new byte[1016];
+      for (int i = 0; i < values[blockNum].length; i++) {
+        values[blockNum][i] = (byte) (blockNum + 1);
+      }
+    }
+
+    // Saturate the queue file
+    queue.add(values[0]);
+    queue.add(values[1]);
+    queue.add(values[2]);
+    queue.add(values[3]);
+
+    // Remove an element and add a new one so that the position of the start and
+    // end of the queue are equal
+    queue.remove();
+    queue.add(values[4]);
+
+    // Cause the queue file to expand
+    queue.add(values[5]);
+
+    // Make sure values are not corrupted
+    for (int i = 1; i < 6; i++) {
+      assertThat(queue.peek()).isEqualTo(values[i]);
+      queue.remove();
+    }
+
+    queue.close();
+  }
+
+  /**
    * A RandomAccessFile that can break when you go to write the COMMITTED
    * status.
    */


### PR DESCRIPTION
If a `QueueFile` has no unused space, and the first element begins somewhere other than at the beginning of the queue, elements at the beginning of the file are not copied after the existing elements as the file is expanded. The next `peek()` may then return no data or corrupted data.

This change contains a test to demonstrate the flaw and simple fix.
