### PR TITLE
Add support for queue file sizes that are larger than 2G

### DIFF
--- a/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadQueueSizeEvent.java
+++ b/tape-sample/src/main/java/com/squareup/tape/sample/ImageUploadQueueSizeEvent.java
@@ -2,9 +2,9 @@
 package com.squareup.tape.sample;
 
 public class ImageUploadQueueSizeEvent {
-  public final int size;
+  public final long size;
 
-  public ImageUploadQueueSizeEvent(int size) {
+  public ImageUploadQueueSizeEvent(long size) {
     this.size = size;
   }
 }

--- a/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
@@ -212,6 +212,8 @@ public abstract class AbstractQueueFile implements QueueFile {
   protected abstract void writeHeader(RandomAccessFile raf, long fileLength, long elementCount, long firstPosition,
                                       long lastPosition) throws IOException;
 
+  protected abstract long getMaxFileSize();
+
   /**
    * Returns the number of used bytes.
    */
@@ -337,7 +339,10 @@ public abstract class AbstractQueueFile implements QueueFile {
     // Double the length until we can fit the new data.
     do {
       remainingBytes += previousLength;
-      newLength = previousLength << 1;
+      newLength = Math.min(getMaxFileSize(), previousLength << 1);
+      if (newLength == previousLength) {
+        throw new IOException("cannot expand file anymore");
+      }
       previousLength = newLength;
     } while (remainingBytes < elementLength);
 

--- a/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
@@ -215,7 +215,7 @@ public abstract class AbstractQueueFile implements QueueFile {
   /**
    * Returns the number of used bytes.
    */
-  private long usedBytes() {
+  long usedBytes() {
     if (elementCount == 0) return headerLength;
 
     if (last.position >= first.position) {

--- a/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/AbstractQueueFile.java
@@ -1,0 +1,619 @@
+package com.squareup.tape;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.lang.Math.min;
+
+/**
+ * A reliable, efficient, file-based, FIFO queue. Additions and removals are
+ * O(1). All operations are atomic. Writes are synchronous; data will be written
+ * to disk before an operation returns. The underlying file is structured to
+ * survive process and even system crashes. If an I/O exception is thrown during
+ * a mutating change, the change is aborted. It is safe to continue to use a
+ * {@code QueueFile} instance after an exception.
+ * <p/>
+ * <p>All operations are synchronized. In a traditional queue, the remove
+ * operation returns an element. In this queue, {@link #peek} and {@link
+ * #remove} are used in conjunction. Use {@code peek} to retrieve the first
+ * element, and then {@code remove} to remove it after successful processing. If
+ * the system crashes after {@code peek} and during processing, the element will
+ * remain in the queue, to be processed when the system restarts.
+ * <p/>
+ * <p><strong>NOTE:</strong> The current implementation is built
+ * for file systems that support atomic segment writes (like YAFFS). Most
+ * conventional file systems don't support this; if the power goes out while
+ * writing a segment, the segment will contain garbage and the file will be
+ * corrupt. We'll add journaling support so this class can be used with more
+ * file systems later.
+ * <p/>
+ * <p>This abstract implementation contains logic shared between BigQueueFileImpl
+ * and QueueFileImpl. All operations assume that the file size can extend beyond
+ * 2G (this is limited manually within QueueFileImpl). Element sizes are
+ * restricted to be less than 2G however (since byte array cannot be larger than
+ * that).
+ *
+ * @author Bob Lee (bob@squareup.com)
+ * @author Clement Pang (me@clementpang.com)
+ */
+public abstract class AbstractQueueFile implements QueueFile {
+
+  private static final Logger LOGGER = Logger.getLogger(AbstractQueueFile.class.getName());
+
+  /**
+   * Initial file size in bytes.
+   */
+  protected static final int INITIAL_LENGTH = 4096; // one file system block
+  /**
+   * A block of nothing to write over old data.
+   */
+  protected static final byte[] ZEROES = new byte[INITIAL_LENGTH];
+
+  protected final int headerLength;
+  /**
+   * In-memory buffer. Big enough to hold the header.
+   */
+  protected final byte[] buffer;
+
+  /**
+   * The underlying file. Uses a ring buffer to store entries. Designed so that
+   * a modification isn't committed or visible until we write the header. The
+   * header is much smaller than a segment. So long as the underlying file
+   * system supports atomic segment writes, changes to the queue are atomic.
+   * Storing the file length ensures we can recover from a failed expansion
+   * (i.e. if setting the file length succeeds but the process dies before the
+   * data can be copied).
+   * <p/>
+   * Visible for testing.
+   */
+  protected final RandomAccessFile raf;
+
+  /**
+   * Cached file length. Always a power of 2.
+   */
+  protected long fileLength;
+
+  /**
+   * Number of elements.
+   */
+  protected long elementCount;
+
+  /**
+   * Pointer to first (or eldest) element.
+   */
+  protected Element first;
+
+  /**
+   * Pointer to last (or newest) element.
+   */
+  protected Element last;
+
+  protected AbstractQueueFile(File file, int headerLength) throws IOException {
+    this.headerLength = headerLength;
+    this.buffer = new byte[headerLength];
+    if (!file.exists()) {
+      raf = initialize(file);
+    } else {
+      raf = open(file);
+    }
+  }
+
+  protected AbstractQueueFile(RandomAccessFile raf, int headerLength) {
+    this.headerLength = headerLength;
+    this.buffer = new byte[headerLength];
+    this.raf = raf;
+  }
+
+  /**
+   * Opens a random access file that writes synchronously.
+   */
+  private static RandomAccessFile open(File file) throws FileNotFoundException {
+    return new RandomAccessFile(file, "rwd");
+  }
+
+  /**
+   * Stores int in buffer. The behavior is equivalent to calling {@link
+   * java.io.RandomAccessFile#writeInt}.
+   */
+  protected static void writeInt(byte[] buffer, int offset, int value) {
+    buffer[offset] = (byte) (value >> 24);
+    buffer[offset + 1] = (byte) (value >> 16);
+    buffer[offset + 2] = (byte) (value >> 8);
+    buffer[offset + 3] = (byte) value;
+  }
+
+  /**
+   * Stores int values in buffer. The behavior is equivalent to calling {@link
+   * java.io.RandomAccessFile#writeInt} for each value.
+   */
+  protected static void writeInts(byte[] buffer, int... values) {
+    int offset = 0;
+    for (int value : values) {
+      writeInt(buffer, offset, value);
+      offset += 4;
+    }
+  }
+
+  /**
+   * Reads an int from a byte[].
+   */
+  protected static int readInt(byte[] buffer, int offset) {
+    return ((buffer[offset] & 0xff) << 24)
+        + ((buffer[offset + 1] & 0xff) << 16)
+        + ((buffer[offset + 2] & 0xff) << 8)
+        + (buffer[offset + 3] & 0xff);
+  }
+
+  /**
+   * Returns t unless it's null.
+   *
+   * @throws NullPointerException if t is null
+   */
+  protected static <T> T nonNull(T t, String name) {
+    if (t == null) throw new NullPointerException(name);
+    return t;
+  }
+
+  /**
+   * Stores long in buffer. The behavior is equivalent to calling {@link
+   * java.io.RandomAccessFile#writeLong(long)}.
+   */
+  protected static void writeLong(byte[] buffer, int offset, long value) {
+    ByteBuffer.wrap(buffer).putLong(offset, value);
+  }
+
+  /**
+   * Stores long values in buffer. The behavior is equivalent to calling {@link
+   * java.io.RandomAccessFile#writeLong(long)} for each value.
+   */
+  protected static void writeLongs(byte[] buffer, long... values) {
+    int offset = 0;
+    for (long value : values) {
+      writeLong(buffer, offset, value);
+      offset += 8;
+    }
+  }
+
+  /**
+   * Reads an long from a byte[].
+   */
+  protected static long readLong(byte[] buffer, int offset) {
+    return ByteBuffer.wrap(buffer).getLong(offset);
+  }
+
+  /**
+   * Initialize the buffer if it does not yet exist.
+   *
+   * @param file File to initialize. Does not yet exist.
+   */
+  private RandomAccessFile initialize(File file) throws IOException {
+    // Use a temp file so we don't leave a partially-initialized file.
+    File tempFile = new File(file.getPath() + ".tmp");
+    RandomAccessFile raf = open(tempFile);
+    try {
+      raf.setLength(INITIAL_LENGTH);
+      raf.seek(0);
+      writeHeader(raf, INITIAL_LENGTH, 0, 0, 0);
+    } finally {
+      raf.close();
+    }
+
+    // A rename is atomic.
+    if (!tempFile.renameTo(file)) throw new IOException("Rename failed!");
+    return open(file);
+  }
+
+  protected abstract void writeHeader(long fileLength, long elementCount, long firstPosition, long lastPosition) throws IOException;
+
+  protected abstract void writeHeader(RandomAccessFile raf, long fileLength, long elementCount, long firstPosition,
+                                      long lastPosition) throws IOException;
+
+  /**
+   * Returns the number of used bytes.
+   */
+  private long usedBytes() {
+    if (elementCount == 0) return headerLength;
+
+    if (last.position >= first.position) {
+      // Contiguous queue.
+      return (last.position - first.position)   // all but last entry
+          + Element.HEADER_LENGTH + last.length // last entry
+          + headerLength;
+    } else {
+      // tail < head. The queue wraps.
+      return last.position                      // buffer front + header
+          + Element.HEADER_LENGTH + last.length // last entry
+          + fileLength - first.position;        // buffer end
+    }
+  }
+
+  /**
+   * Returns number of unused bytes.
+   */
+  private long remainingBytes() {
+    return fileLength - usedBytes();
+  }
+
+  /**
+   * Returns true if this queue contains no entries.
+   */
+  public synchronized boolean isEmpty() {
+    return elementCount == 0;
+  }
+
+  /**
+   * Reads the eldest element. Returns null if the queue is empty.
+   */
+  public synchronized byte[] peek() throws IOException {
+    if (isEmpty()) return null;
+    int length = first.length;
+    byte[] data = new byte[length];
+    ringRead(first.position + Element.HEADER_LENGTH, data, 0, length);
+    return data;
+  }
+
+  /**
+   * Invokes reader with the eldest element, if an element is available.
+   */
+  public synchronized void peek(QueueFile.ElementReader reader) throws IOException {
+    if (elementCount > 0) {
+      reader.read(new ElementInputStream(first), first.length);
+    }
+  }
+
+  /**
+   * Invokes the given reader once for each element in the queue, from eldest to
+   * most recently added.
+   */
+  public synchronized void forEach(QueueFile.ElementReader reader) throws IOException {
+    long position = first.position;
+    for (int i = 0; i < elementCount; i++) {
+      Element current = readElement(position);
+      reader.read(new ElementInputStream(current), current.length);
+      position = wrapPosition(current.position + Element.HEADER_LENGTH + current.length);
+    }
+  }
+
+  @Override
+  public void add(byte[] data) throws IOException {
+    add(data, 0, data.length);
+  }
+
+  /**
+   * Adds an element to the end of the queue.
+   *
+   * @param data   to copy bytes from
+   * @param offset to start from in buffer
+   * @param count  number of bytes to copy
+   * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code count < 0}, or if {@code offset + count} is
+   *                                   bigger than the length of {@code buffer}.
+   */
+  public synchronized void add(byte[] data, int offset, int count) throws IOException {
+    nonNull(data, "buffer");
+    if ((offset | count) < 0 || count > data.length - offset) {
+      throw new IndexOutOfBoundsException();
+    }
+
+    expandIfNecessary(count);
+
+    // Insert a new element after the current last element.
+    boolean wasEmpty = isEmpty();
+    long position = wasEmpty ? headerLength : wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
+    Element newLast = new Element(position, count);
+
+    // Write length.
+    writeInt(buffer, 0, count);
+    ringWrite(newLast.position, buffer, 0, Element.HEADER_LENGTH);
+
+    // Write data.
+    ringWrite(newLast.position + Element.HEADER_LENGTH, data, offset, count);
+
+    // Commit the addition. If wasEmpty, first == last.
+    long firstPosition = wasEmpty ? newLast.position : first.position;
+    writeHeader(fileLength, elementCount + 1, firstPosition, newLast.position);
+    last = newLast;
+    elementCount++;
+    if (wasEmpty) first = last; // first element
+  }
+
+  /**
+   * If necessary, expands the file to accommodate an additional element of the
+   * given length.
+   *
+   * @param dataLength length of data being added
+   */
+  private void expandIfNecessary(long dataLength) throws IOException {
+    long elementLength = Element.HEADER_LENGTH + dataLength;
+    long remainingBytes = remainingBytes();
+    if (remainingBytes >= elementLength) return;
+
+    // Expand.
+    long previousLength = fileLength;
+    long newLength;
+    // Double the length until we can fit the new data.
+    do {
+      remainingBytes += previousLength;
+      newLength = previousLength << 1;
+      previousLength = newLength;
+    } while (remainingBytes < elementLength);
+
+    setLength(newLength);
+
+    // Calculate the position of the tail end of the data in the ring buffer
+    long endOfLastElement = wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
+
+    // If the buffer is split, we need to make it contiguous
+    if (endOfLastElement <= first.position) {
+      FileChannel channel = raf.getChannel();
+      channel.position(fileLength); // destination position
+      long count = endOfLastElement - Element.HEADER_LENGTH;
+      if (channel.transferTo(headerLength, count, channel) != count) {
+        throw new AssertionError("Copied insufficient number of bytes!");
+      }
+    }
+
+    // Commit the expansion.
+    if (last.position < first.position) {
+      long newLastPosition = fileLength + last.position - headerLength;
+      writeHeader(newLength, elementCount, first.position, newLastPosition);
+      last = new Element(newLastPosition, last.length);
+    } else {
+      writeHeader(newLength, elementCount, first.position, last.position);
+    }
+
+    fileLength = newLength;
+  }
+
+  /**
+   * Writes count bytes from buffer to position in file. Automatically wraps
+   * write if position is past the end of the file or if buffer overlaps it.
+   *
+   * @param position in file to write to
+   * @param buffer   to write from
+   * @param offset   offset in the buffer to start writing
+   * @param count    # of bytes to write
+   */
+  private void ringWrite(long position, byte[] buffer, int offset, int count) throws IOException {
+    position = wrapPosition(position);
+    if (position + count <= fileLength) {
+      raf.seek(position);
+      raf.write(buffer, offset, count);
+    } else {
+      // The write overlaps the EOF.
+      // # of bytes to write before the EOF.
+      int beforeEof = (int) (fileLength - position);
+      raf.seek(position);
+      raf.write(buffer, offset, beforeEof);
+      raf.seek(headerLength);
+      raf.write(buffer, offset + beforeEof, count - beforeEof);
+    }
+  }
+
+  private void ringErase(long position, int length) throws IOException {
+    while (length > 0) {
+      int chunk = min(length, ZEROES.length);
+      ringWrite(position, ZEROES, 0, chunk);
+      length -= chunk;
+      position += chunk;
+    }
+  }
+
+  /**
+   * Reads count bytes into buffer from file. Wraps if necessary.
+   *
+   * @param position in file to read from
+   * @param buffer   to read into
+   * @param count    # of bytes to read
+   */
+  private void ringRead(long position, byte[] buffer, int offset, int count) throws IOException {
+    position = wrapPosition(position);
+    if (position + count <= fileLength) {
+      raf.seek(position);
+      raf.readFully(buffer, offset, count);
+    } else {
+      // The read overlaps the EOF.
+      // # of bytes to read before the EOF.
+      int beforeEof = (int) (fileLength - position);
+      raf.seek(position);
+      raf.readFully(buffer, offset, beforeEof);
+      raf.seek(headerLength);
+      raf.readFully(buffer, offset + beforeEof, count - beforeEof);
+    }
+  }
+
+  /**
+   * Wraps the position if it exceeds the end of the file.
+   */
+  private long wrapPosition(long position) {
+    return position < fileLength ? position
+        : headerLength + position - fileLength;
+  }
+
+  /**
+   * Returns the Element for the given offset.
+   */
+  protected Element readElement(long position) throws IOException {
+    if (position == 0) return Element.NULL;
+    raf.seek(position);
+    return new Element(position, raf.readInt());
+  }
+
+  /**
+   * Sets the length of the file.
+   */
+  private void setLength(long newLength) throws IOException {
+    // Set new file length (considered metadata) and sync it to storage.
+    raf.setLength(newLength);
+    raf.getChannel().force(true);
+  }
+
+  /**
+   * Clears this queue. Truncates the file to the initial size.
+   */
+  public synchronized void clear() throws IOException {
+    raf.seek(0);
+    raf.write(ZEROES);
+    writeHeader(INITIAL_LENGTH, 0, 0, 0);
+    elementCount = 0;
+    first = Element.NULL;
+    last = Element.NULL;
+    if (fileLength > INITIAL_LENGTH) setLength(INITIAL_LENGTH);
+    fileLength = INITIAL_LENGTH;
+  }
+
+  /**
+   * Returns the number of elements in this queue.
+   */
+  public synchronized long size() {
+    return elementCount;
+  }
+
+  /**
+   * Removes the eldest element.
+   *
+   * @throws java.util.NoSuchElementException if the queue is empty
+   */
+  public synchronized void remove() throws IOException {
+    if (isEmpty()) throw new NoSuchElementException();
+    if (elementCount == 1) {
+      clear();
+    } else {
+      // assert elementCount > 1
+      int firstTotalLength = Element.HEADER_LENGTH + first.length;
+
+      ringErase(first.position, firstTotalLength);
+
+      long newFirstPosition = wrapPosition(first.position + firstTotalLength);
+      ringRead(newFirstPosition, buffer, 0, Element.HEADER_LENGTH);
+      int length = readInt(buffer, 0);
+      writeHeader(fileLength, elementCount - 1, newFirstPosition, last.position);
+      elementCount--;
+      first = new Element(newFirstPosition, length);
+    }
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder builder = new StringBuilder();
+    builder.append(getClass().getSimpleName()).append('[');
+    builder.append("fileLength=").append(fileLength);
+    builder.append(", size=").append(elementCount);
+    builder.append(", first=").append(first);
+    builder.append(", last=").append(last);
+    builder.append(", element lengths=[");
+    try {
+      forEach(new QueueFile.ElementReader() {
+        boolean first = true;
+
+        @Override
+        public void read(InputStream in, int length) throws IOException {
+          if (first) {
+            first = false;
+          } else {
+            builder.append(", ");
+          }
+          builder.append(length);
+        }
+      });
+    } catch (IOException e) {
+      LOGGER.log(Level.WARNING, "read error", e);
+    }
+    builder.append("]]");
+    return builder.toString();
+  }
+
+  /**
+   * Closes the underlying file.
+   */
+  public synchronized void close() throws IOException {
+    raf.close();
+  }
+
+  /**
+   * A pointer to an element.
+   */
+  static class Element {
+
+    /**
+     * Length of element header in bytes.
+     */
+    static final int HEADER_LENGTH = 4;
+
+    /**
+     * Null element.
+     */
+    static final Element NULL = new Element(0, 0);
+
+    /**
+     * Position in file.
+     */
+    final long position;
+
+    /**
+     * The length of the data.
+     */
+    final int length;
+
+    /**
+     * Constructs a new element.
+     *
+     * @param position within file
+     * @param length   of data
+     */
+    Element(long position, int length) {
+      this.position = position;
+      this.length = length;
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName() + "["
+          + "position = " + position
+          + ", length = " + length + "]";
+    }
+  }
+
+  /**
+   * Reads a single element.
+   */
+  private final class ElementInputStream extends InputStream {
+    private long position;
+    private int remaining;
+
+    private ElementInputStream(Element element) {
+      position = wrapPosition(element.position + Element.HEADER_LENGTH);
+      remaining = element.length;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      nonNull(buffer, "buffer");
+      if ((offset | length) < 0 || length > buffer.length - offset) {
+        throw new ArrayIndexOutOfBoundsException();
+      }
+      if (remaining > 0) {
+        if (length > remaining) length = remaining;
+        ringRead(position, buffer, offset, length);
+        position = wrapPosition(position + length);
+        remaining -= length;
+        return length;
+      } else {
+        return -1;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (remaining == 0) return -1;
+      raf.seek(position);
+      int b = raf.read();
+      position = wrapPosition(position + 1);
+      remaining--;
+      return b;
+    }
+  }
+}

--- a/tape/src/main/java/com/squareup/tape/BigQueueFileImpl.java
+++ b/tape/src/main/java/com/squareup/tape/BigQueueFileImpl.java
@@ -87,4 +87,9 @@ public class BigQueueFileImpl extends AbstractQueueFile {
     raf.seek(0);
     raf.write(buffer);
   }
+
+  @Override
+  protected long getMaxFileSize() {
+    return Long.MAX_VALUE;
+  }
 }

--- a/tape/src/main/java/com/squareup/tape/BigQueueFileImpl.java
+++ b/tape/src/main/java/com/squareup/tape/BigQueueFileImpl.java
@@ -1,0 +1,90 @@
+package com.squareup.tape;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/**
+ * A QueueFile implementation that supports files larger than 2G. Note that files are NOT
+ * compatible with {@link QueueFileImpl} since the header format is different.
+ * <p>Buffer file format:
+ * <pre>
+ *   Format:
+ *     Header              (32 bytes)
+ *     Element Ring Buffer (File Length - 32 bytes)
+ *
+ *   Header:
+ *     File Length            (8 bytes)
+ *     Element Count          (8 bytes)
+ *     First Element Position (8 bytes, =0 if null)
+ *     Last Element Position  (8 bytes, =0 if null)
+ *
+ *   Element:
+ *     Length (4 bytes)
+ *     Data   (Length bytes)
+ * </pre>
+ *
+ * @author Clement Pang (me@clementpang.com)
+ */
+public class BigQueueFileImpl extends AbstractQueueFile {
+
+  /**
+   * Length of header in bytes.
+   */
+  static final int HEADER_LENGTH = 32;
+
+  /**
+   * Constructs a new queue backed by the given file. Only one {@code QueueFile}
+   * instance should access a given file at a time.
+   */
+  public BigQueueFileImpl(File file) throws IOException {
+    super(file, HEADER_LENGTH);
+    readHeader();
+  }
+
+  /**
+   * For testing.
+   */
+  BigQueueFileImpl(RandomAccessFile raf) throws IOException {
+    super(raf, HEADER_LENGTH);
+    readHeader();
+  }
+
+  /**
+   * Reads the header.
+   */
+  private void readHeader() throws IOException {
+    raf.seek(0);
+    raf.readFully(buffer);
+    fileLength = readLong(buffer, 0);
+    if (fileLength > raf.length()) {
+      throw new IOException("File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
+    } else if (fileLength == 0) {
+      throw new IOException("File is corrupt; length stored in header is 0.");
+    }
+    elementCount = readLong(buffer, 8);
+    long firstOffset = readLong(buffer, 16);
+    long lastOffset = readLong(buffer, 24);
+    first = readElement(firstOffset);
+    last = readElement(lastOffset);
+  }
+
+  @Override
+  protected void writeHeader(long fileLength, long elementCount, long firstPosition, long lastPosition) throws IOException {
+    writeHeader(raf, fileLength, elementCount, firstPosition, lastPosition);
+  }
+
+  /**
+   * Writes header atomically. The arguments contain the updated values. The
+   * class member fields should not have changed yet. This only updates the
+   * state in the file. It's up to the caller to update the class member
+   * variables *after* this call succeeds. Assumes segment writes are atomic in
+   * the underlying file system.
+   */
+  @Override
+  protected void writeHeader(RandomAccessFile raf, long fileLength, long elementCount, long firstPosition, long lastPosition) throws IOException {
+    writeLongs(buffer, fileLength, elementCount, firstPosition, lastPosition);
+    raf.seek(0);
+    raf.write(buffer);
+  }
+}

--- a/tape/src/main/java/com/squareup/tape/FileObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/FileObjectQueue.java
@@ -14,7 +14,7 @@ import java.io.OutputStream;
  * <p>
  * The {@link #add( Object )}, {@link #peek()}, {@link #remove()}, and
  * {@link #setListener(ObjectQueue.Listener)} methods may throw a
- * {@link FileException} if the underlying {@link QueueFile} experiences an
+ * {@link FileException} if the underlying {@link QueueFileImpl} experiences an
  * {@link java.io.IOException}.
  *
  * @param <T> The type of elements in the queue.
@@ -32,10 +32,16 @@ public class FileObjectQueue<T> implements ObjectQueue<T> {
   public FileObjectQueue(File file, Converter<T> converter) throws IOException {
     this.file = file;
     this.converter = converter;
-    this.queueFile = new QueueFile(file);
+    this.queueFile = QueueFileFactory.open(file);
   }
 
-  @Override public int size() {
+  public FileObjectQueue(File file, Converter<T> converter, QueueFile queueFile) throws IOException {
+    this.file = file;
+    this.converter = converter;
+    this.queueFile = queueFile;
+  }
+
+  @Override public long size() {
     return queueFile.size();
   }
 
@@ -72,7 +78,7 @@ public class FileObjectQueue<T> implements ObjectQueue<T> {
   @Override public void setListener(final Listener<T> listener) {
     if (listener != null) {
       try {
-        queueFile.forEach(new QueueFile.ElementReader() {
+        queueFile.forEach(new QueueFileImpl.ElementReader() {
           @Override
           public void read(InputStream in, int length) throws IOException {
             byte[] data = new byte[length];

--- a/tape/src/main/java/com/squareup/tape/InMemoryObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/InMemoryObjectQueue.java
@@ -28,7 +28,7 @@ public class InMemoryObjectQueue<T> implements ObjectQueue<T> {
     return tasks.peek();
   }
 
-  @Override public int size() {
+  @Override public long size() {
     return tasks.size();
   }
 

--- a/tape/src/main/java/com/squareup/tape/ObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/ObjectQueue.java
@@ -9,7 +9,7 @@ package com.squareup.tape;
 public interface ObjectQueue<T> {
 
   /** Returns the number of entries in the queue. */
-  int size();
+  long size();
 
   /** Enqueues an entry that can be processed at any time. */
   void add(T entry);

--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -1,290 +1,21 @@
-/*
- * Copyright (C) 2010 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.squareup.tape;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.RandomAccessFile;
-import java.nio.channels.FileChannel;
-import java.util.NoSuchElementException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static java.lang.Math.min;
 
 /**
- * A reliable, efficient, file-based, FIFO queue. Additions and removals are
- * O(1). All operations are atomic. Writes are synchronous; data will be written
- * to disk before an operation returns. The underlying file is structured to
- * survive process and even system crashes. If an I/O exception is thrown during
- * a mutating change, the change is aborted. It is safe to continue to use a
- * {@code QueueFile} instance after an exception.
- *
- * <p>All operations are synchronized. In a traditional queue, the remove
- * operation returns an element. In this queue, {@link #peek} and {@link
- * #remove} are used in conjunction. Use {@code peek} to retrieve the first
- * element, and then {@code remove} to remove it after successful processing. If
- * the system crashes after {@code peek} and during processing, the element will
- * remain in the queue, to be processed when the system restarts.
- *
- * <p><strong>NOTE:</strong> The current implementation is built
- * for file systems that support atomic segment writes (like YAFFS). Most
- * conventional file systems don't support this; if the power goes out while
- * writing a segment, the segment will contain garbage and the file will be
- * corrupt. We'll add journaling support so this class can be used with more
- * file systems later.
+ * Queue File interface.
  *
  * @author Bob Lee (bob@squareup.com)
+ * @author Clement Pang (me@clementpang.com)
  */
-public class QueueFile {
-  private static final Logger LOGGER = Logger.getLogger(QueueFile.class.getName());
-
-  /** Initial file size in bytes. */
-  private static final int INITIAL_LENGTH = 4096; // one file system block
-
-  /** A block of nothing to write over old data. */
-  private static final byte[] ZEROES = new byte[INITIAL_LENGTH];
-
-  /** Length of header in bytes. */
-  static final int HEADER_LENGTH = 16;
-
-  /**
-   * The underlying file. Uses a ring buffer to store entries. Designed so that
-   * a modification isn't committed or visible until we write the header. The
-   * header is much smaller than a segment. So long as the underlying file
-   * system supports atomic segment writes, changes to the queue are atomic.
-   * Storing the file length ensures we can recover from a failed expansion
-   * (i.e. if setting the file length succeeds but the process dies before the
-   * data can be copied).
-   * <p/>
-   * <pre>
-   *   Format:
-   *     Header              (16 bytes)
-   *     Element Ring Buffer (File Length - 16 bytes)
-   * <p/>
-   *   Header:
-   *     File Length            (4 bytes)
-   *     Element Count          (4 bytes)
-   *     First Element Position (4 bytes, =0 if null)
-   *     Last Element Position  (4 bytes, =0 if null)
-   * <p/>
-   *   Element:
-   *     Length (4 bytes)
-   *     Data   (Length bytes)
-   * </pre>
-   *
-   * Visible for testing.
-   */
-  final RandomAccessFile raf;
-
-  /** Cached file length. Always a power of 2. */
-  int fileLength;
-
-  /** Number of elements. */
-  private int elementCount;
-
-  /** Pointer to first (or eldest) element. */
-  private Element first;
-
-  /** Pointer to last (or newest) element. */
-  private Element last;
-
-  /** In-memory buffer. Big enough to hold the header. */
-  private final byte[] buffer = new byte[16];
-
-  /**
-   * Constructs a new queue backed by the given file. Only one {@code QueueFile}
-   * instance should access a given file at a time.
-   */
-  public QueueFile(File file) throws IOException {
-    if (!file.exists()) initialize(file);
-    raf = open(file);
-    readHeader();
-  }
-
-  /** For testing. */
-  QueueFile(RandomAccessFile raf) throws IOException {
-    this.raf = raf;
-    readHeader();
-  }
-
-  /**
-   * Stores int in buffer. The behavior is equivalent to calling {@link
-   * java.io.RandomAccessFile#writeInt}.
-   */
-  private static void writeInt(byte[] buffer, int offset, int value) {
-    buffer[offset] = (byte) (value >> 24);
-    buffer[offset + 1] = (byte) (value >> 16);
-    buffer[offset + 2] = (byte) (value >> 8);
-    buffer[offset + 3] = (byte) value;
-  }
-
-  /**
-   * Stores int values in buffer. The behavior is equivalent to calling {@link
-   * java.io.RandomAccessFile#writeInt} for each value.
-   */
-  private static void writeInts(byte[] buffer, int... values) {
-    int offset = 0;
-    for (int value : values) {
-      writeInt(buffer, offset, value);
-      offset += 4;
-    }
-  }
-
-  /** Reads an int from a byte[]. */
-  private static int readInt(byte[] buffer, int offset) {
-    return ((buffer[offset] & 0xff) << 24)
-        + ((buffer[offset + 1] & 0xff) << 16)
-        + ((buffer[offset + 2] & 0xff) << 8)
-        + (buffer[offset + 3] & 0xff);
-  }
-
-  /** Reads the header. */
-  private void readHeader() throws IOException {
-    raf.seek(0);
-    raf.readFully(buffer);
-    fileLength = readInt(buffer, 0);
-    if (fileLength > raf.length()) {
-      throw new IOException("File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
-    } else if (fileLength == 0) {
-      throw new IOException("File is corrupt; length stored in header is 0.");
-    }
-    elementCount = readInt(buffer, 4);
-    int firstOffset = readInt(buffer, 8);
-    int lastOffset = readInt(buffer, 12);
-    first = readElement(firstOffset);
-    last = readElement(lastOffset);
-  }
-
-  /**
-   * Writes header atomically. The arguments contain the updated values. The
-   * class member fields should not have changed yet. This only updates the
-   * state in the file. It's up to the caller to update the class member
-   * variables *after* this call succeeds. Assumes segment writes are atomic in
-   * the underlying file system.
-   */
-  private void writeHeader(int fileLength, int elementCount, int firstPosition, int lastPosition) throws IOException {
-    writeInts(buffer, fileLength, elementCount, firstPosition, lastPosition);
-    raf.seek(0);
-    raf.write(buffer);
-  }
-
-  /** Returns the Element for the given offset. */
-  private Element readElement(int position) throws IOException {
-    if (position == 0) return Element.NULL;
-    raf.seek(position);
-    return new Element(position, raf.readInt());
-  }
-
-  /** Atomically initializes a new file. */
-  private static void initialize(File file) throws IOException {
-    // Use a temp file so we don't leave a partially-initialized file.
-    File tempFile = new File(file.getPath() + ".tmp");
-    RandomAccessFile raf = open(tempFile);
-    try {
-      raf.setLength(INITIAL_LENGTH);
-      raf.seek(0);
-      byte[] headerBuffer = new byte[16];
-      writeInts(headerBuffer, INITIAL_LENGTH, 0, 0, 0);
-      raf.write(headerBuffer);
-    } finally {
-      raf.close();
-    }
-
-    // A rename is atomic.
-    if (!tempFile.renameTo(file)) throw new IOException("Rename failed!");
-  }
-
-  /** Opens a random access file that writes synchronously. */
-  private static RandomAccessFile open(File file) throws FileNotFoundException {
-    return new RandomAccessFile(file, "rwd");
-  }
-
-  /** Wraps the position if it exceeds the end of the file. */
-  private int wrapPosition(int position) {
-    return position < fileLength ? position
-        : HEADER_LENGTH + position - fileLength;
-  }
-
-  /**
-   * Writes count bytes from buffer to position in file. Automatically wraps
-   * write if position is past the end of the file or if buffer overlaps it.
-   *
-   * @param position in file to write to
-   * @param buffer   to write from
-   * @param count    # of bytes to write
-   */
-  private void ringWrite(int position, byte[] buffer, int offset, int count) throws IOException {
-    position = wrapPosition(position);
-    if (position + count <= fileLength) {
-      raf.seek(position);
-      raf.write(buffer, offset, count);
-    } else {
-      // The write overlaps the EOF.
-      // # of bytes to write before the EOF.
-      int beforeEof = fileLength - position;
-      raf.seek(position);
-      raf.write(buffer, offset, beforeEof);
-      raf.seek(HEADER_LENGTH);
-      raf.write(buffer, offset + beforeEof, count - beforeEof);
-    }
-  }
-
-  private void ringErase(int position, int length) throws IOException {
-    while (length > 0) {
-      int chunk = min(length, ZEROES.length);
-      ringWrite(position, ZEROES, 0, chunk);
-      length -= chunk;
-      position += chunk;
-    }
-  }
-
-  /**
-   * Reads count bytes into buffer from file. Wraps if necessary.
-   *
-   * @param position in file to read from
-   * @param buffer   to read into
-   * @param count    # of bytes to read
-   */
-  private void ringRead(int position, byte[] buffer, int offset, int count) throws IOException {
-    position = wrapPosition(position);
-    if (position + count <= fileLength) {
-      raf.seek(position);
-      raf.readFully(buffer, offset, count);
-    } else {
-      // The read overlaps the EOF.
-      // # of bytes to read before the EOF.
-      int beforeEof = fileLength - position;
-      raf.seek(position);
-      raf.readFully(buffer, offset, beforeEof);
-      raf.seek(HEADER_LENGTH);
-      raf.readFully(buffer, offset + beforeEof, count - beforeEof);
-    }
-  }
-
+public interface QueueFile {
   /**
    * Adds an element to the end of the queue.
    *
    * @param data to copy bytes from
    */
-  public void add(byte[] data) throws IOException {
-    add(data, 0, data.length);
-  }
+  void add(byte[] data) throws IOException;
 
   /**
    * Adds an element to the end of the queue.
@@ -295,297 +26,50 @@ public class QueueFile {
    * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code count < 0}, or if {@code offset + count} is
    *                                   bigger than the length of {@code buffer}.
    */
-  public synchronized void add(byte[] data, int offset, int count) throws IOException {
-    nonNull(data, "buffer");
-    if ((offset | count) < 0 || count > data.length - offset) {
-      throw new IndexOutOfBoundsException();
-    }
-
-    expandIfNecessary(count);
-
-    // Insert a new element after the current last element.
-    boolean wasEmpty = isEmpty();
-    int position = wasEmpty ? HEADER_LENGTH : wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
-    Element newLast = new Element(position, count);
-
-    // Write length.
-    writeInt(buffer, 0, count);
-    ringWrite(newLast.position, buffer, 0, Element.HEADER_LENGTH);
-
-    // Write data.
-    ringWrite(newLast.position + Element.HEADER_LENGTH, data, offset, count);
-
-    // Commit the addition. If wasEmpty, first == last.
-    int firstPosition = wasEmpty ? newLast.position : first.position;
-    writeHeader(fileLength, elementCount + 1, firstPosition, newLast.position);
-    last = newLast;
-    elementCount++;
-    if (wasEmpty) first = last; // first element
-  }
-
-  /** Returns the number of used bytes. */
-  private int usedBytes() {
-    if (elementCount == 0) return HEADER_LENGTH;
-
-    if (last.position >= first.position) {
-      // Contiguous queue.
-      return (last.position - first.position)   // all but last entry
-          + Element.HEADER_LENGTH + last.length // last entry
-          + HEADER_LENGTH;
-    } else {
-      // tail < head. The queue wraps.
-      return last.position                      // buffer front + header
-          + Element.HEADER_LENGTH + last.length // last entry
-          + fileLength - first.position;        // buffer end
-    }
-  }
-
-  /** Returns number of unused bytes. */
-  private int remainingBytes() {
-    return fileLength - usedBytes();
-  }
-
-  /** Returns true if this queue contains no entries. */
-  public synchronized boolean isEmpty() {
-    return elementCount == 0;
-  }
+  void add(byte[] data, int offset, int count) throws IOException;
 
   /**
-   * If necessary, expands the file to accommodate an additional element of the
-   * given length.
-   *
-   * @param dataLength length of data being added
+   * Returns true if this queue contains no entries.
    */
-  private void expandIfNecessary(int dataLength) throws IOException {
-    int elementLength = Element.HEADER_LENGTH + dataLength;
-    int remainingBytes = remainingBytes();
-    if (remainingBytes >= elementLength) return;
+  boolean isEmpty();
 
-    // Expand.
-    int previousLength = fileLength;
-    int newLength;
-    // Double the length until we can fit the new data.
-    do {
-      remainingBytes += previousLength;
-      newLength = previousLength << 1;
-      previousLength = newLength;
-    } while (remainingBytes < elementLength);
+  /**
+   * Reads the eldest element. Returns null if the queue is empty.
+   */
+  byte[] peek() throws IOException;
 
-    setLength(newLength);
-
-    // Calculate the position of the tail end of the data in the ring buffer
-    int endOfLastElement = wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
-
-    // If the buffer is split, we need to make it contiguous
-    if (endOfLastElement <= first.position) {
-      FileChannel channel = raf.getChannel();
-      channel.position(fileLength); // destination position
-      int count = endOfLastElement - Element.HEADER_LENGTH;
-      if (channel.transferTo(HEADER_LENGTH, count, channel) != count) {
-        throw new AssertionError("Copied insufficient number of bytes!");
-      }
-    }
-
-    // Commit the expansion.
-    if (last.position < first.position) {
-      int newLastPosition = fileLength + last.position - HEADER_LENGTH;
-      writeHeader(newLength, elementCount, first.position, newLastPosition);
-      last = new Element(newLastPosition, last.length);
-    } else {
-      writeHeader(newLength, elementCount, first.position, last.position);
-    }
-
-    fileLength = newLength;
-  }
-
-  /** Sets the length of the file. */
-  private void setLength(int newLength) throws IOException {
-    // Set new file length (considered metadata) and sync it to storage.
-    raf.setLength(newLength);
-    raf.getChannel().force(true);
-  }
-
-  /** Reads the eldest element. Returns null if the queue is empty. */
-  public synchronized byte[] peek() throws IOException {
-    if (isEmpty()) return null;
-    int length = first.length;
-    byte[] data = new byte[length];
-    ringRead(first.position + Element.HEADER_LENGTH, data, 0, length);
-    return data;
-  }
-
-  /** Invokes reader with the eldest element, if an element is available. */
-  public synchronized void peek(ElementReader reader) throws IOException {
-    if (elementCount > 0) {
-      reader.read(new ElementInputStream(first), first.length);
-    }
-  }
+  /**
+   * Invokes reader with the eldest element, if an element is available.
+   */
+  void peek(ElementReader reader) throws IOException;
 
   /**
    * Invokes the given reader once for each element in the queue, from eldest to
    * most recently added.
    */
-  public synchronized void forEach(ElementReader reader) throws IOException {
-    int position = first.position;
-    for (int i = 0; i < elementCount; i++) {
-      Element current = readElement(position);
-      reader.read(new ElementInputStream(current), current.length);
-      position = wrapPosition(current.position + Element.HEADER_LENGTH + current.length);
-    }
-  }
+  void forEach(ElementReader reader) throws IOException;
 
   /**
-   * Returns t unless it's null.
-   *
-   * @throws NullPointerException if t is null
+   * Returns the number of elements in this queue.
    */
-  private static <T> T nonNull(T t, String name) {
-    if (t == null) throw new NullPointerException(name);
-    return t;
-  }
-
-  /** Reads a single element. */
-  private final class ElementInputStream extends InputStream {
-    private int position;
-    private int remaining;
-
-    private ElementInputStream(Element element) {
-      position = wrapPosition(element.position + Element.HEADER_LENGTH);
-      remaining = element.length;
-    }
-
-    @Override public int read(byte[] buffer, int offset, int length) throws IOException {
-      nonNull(buffer, "buffer");
-      if ((offset | length) < 0 || length > buffer.length - offset) {
-        throw new ArrayIndexOutOfBoundsException();
-      }
-      if (remaining > 0) {
-        if (length > remaining) length = remaining;
-        ringRead(position, buffer, offset, length);
-        position = wrapPosition(position + length);
-        remaining -= length;
-        return length;
-      } else {
-        return -1;
-      }
-    }
-
-    @Override public int read() throws IOException {
-      if (remaining == 0) return -1;
-      raf.seek(position);
-      int b = raf.read();
-      position = wrapPosition(position + 1);
-      remaining--;
-      return b;
-    }
-  }
-
-  /** Returns the number of elements in this queue. */
-  public synchronized int size() {
-    return elementCount;
-  }
+  long size();
 
   /**
    * Removes the eldest element.
    *
    * @throws java.util.NoSuchElementException if the queue is empty
    */
-  public synchronized void remove() throws IOException {
-    if (isEmpty()) throw new NoSuchElementException();
-    if (elementCount == 1) {
-      clear();
-    } else {
-      // assert elementCount > 1
-      int firstTotalLength = Element.HEADER_LENGTH + first.length;
+  void remove() throws IOException;
 
-      ringErase(first.position, firstTotalLength);
+  /**
+   * Clears this queue. Truncates the file to the initial size.
+   */
+  void clear() throws IOException;
 
-      int newFirstPosition = wrapPosition(first.position + firstTotalLength);
-      ringRead(newFirstPosition, buffer, 0, Element.HEADER_LENGTH);
-      int length = readInt(buffer, 0);
-      writeHeader(fileLength, elementCount - 1, newFirstPosition, last.position);
-      elementCount--;
-      first = new Element(newFirstPosition, length);
-    }
-  }
-
-  /** Clears this queue. Truncates the file to the initial size. */
-  public synchronized void clear() throws IOException {
-    raf.seek(0);
-    raf.write(ZEROES);
-    writeHeader(INITIAL_LENGTH, 0, 0, 0);
-    elementCount = 0;
-    first = Element.NULL;
-    last = Element.NULL;
-    if (fileLength > INITIAL_LENGTH) setLength(INITIAL_LENGTH);
-    fileLength = INITIAL_LENGTH;
-  }
-
-  /** Closes the underlying file. */
-  public synchronized void close() throws IOException {
-    raf.close();
-  }
-
-  @Override public String toString() {
-    final StringBuilder builder = new StringBuilder();
-    builder.append(getClass().getSimpleName()).append('[');
-    builder.append("fileLength=").append(fileLength);
-    builder.append(", size=").append(elementCount);
-    builder.append(", first=").append(first);
-    builder.append(", last=").append(last);
-    builder.append(", element lengths=[");
-    try {
-      forEach(new ElementReader() {
-        boolean first = true;
-
-        @Override public void read(InputStream in, int length) throws IOException {
-          if (first) {
-            first = false;
-          } else {
-            builder.append(", ");
-          }
-          builder.append(length);
-        }
-      });
-    } catch (IOException e) {
-      LOGGER.log(Level.WARNING, "read error", e);
-    }
-    builder.append("]]");
-    return builder.toString();
-  }
-
-  /** A pointer to an element. */
-  static class Element {
-
-    /** Length of element header in bytes. */
-    static final int HEADER_LENGTH = 4;
-
-    /** Null element. */
-    static final Element NULL = new Element(0, 0);
-
-    /** Position in file. */
-    final int position;
-
-    /** The length of the data. */
-    final int length;
-
-    /**
-     * Constructs a new element.
-     *
-     * @param position within file
-     * @param length   of data
-     */
-    Element(int position, int length) {
-      this.position = position;
-      this.length = length;
-    }
-
-    @Override public String toString() {
-      return getClass().getSimpleName() + "["
-          + "position = " + position
-          + ", length = " + length + "]";
-    }
-  }
+  /**
+   * Closes the underlying file.
+   */
+  void close() throws IOException;
 
   /**
    * Reads queue elements. Enables partial reads as opposed to reading all of

--- a/tape/src/main/java/com/squareup/tape/QueueFileFactory.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFileFactory.java
@@ -1,0 +1,64 @@
+package com.squareup.tape;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Factory for QueueFiles.
+ *
+ * @author Clement Pang (clement@wavefront.com)
+ */
+public abstract class QueueFileFactory {
+
+  /**
+   * Open a queue file that only supports up to 2G.
+   *
+   * @param file File to use for queue file. Will create and initialize if necessary.
+   * @return The Queue File.
+   * @throws IOException Exceptions when creating the queue file.
+   */
+  public static QueueFile open(File file) throws IOException {
+    return new QueueFileImpl(file);
+  }
+
+  /**
+   * Open a queue file that can span more than 2G (limited by the operating system).
+   *
+   * @param file File to use for queue file. Will create and initialize if necessary.
+   * @return The Queue File.
+   * @throws IOException Exceptions when creating the queue file.
+   */
+  public static QueueFile openLarge(File file) throws IOException {
+    return new BigQueueFileImpl(file);
+  }
+
+  /**
+   * Migrate a queue file that supports up to 2G file size, reading its contents and writing them to a new
+   * queue file that can span up to what's allowed by the operating system.
+   * <p/>
+   * The files must not be the same and new file can already exist as elements are moved one-by-one and if the process
+   * crashes, the migration process will continue. There is a potential of copying the same element twice if the element
+   * did in fact finish writing to the new queue but cannot be removed from the old one.
+   * <p/>
+   * If the old file does not exist, no migration will happen. After migration, the old file can be safely deleted.
+   *
+   * @param oldFile Old file, must be one that's opened by {@link #open(java.io.File)}. If it does not exist, migration
+   *                will not happen.
+   * @param newFile New file.
+   * @return New queue file that's backed by {@link BigQueueFileImpl}.
+   * @throws IOException
+   */
+  public static QueueFile openAndMigrate(File oldFile, File newFile, boolean deleteWhenDone) throws IOException {
+    if (!oldFile.exists()) {
+      return openLarge(newFile);
+    }
+    QueueFile oldQueue = open(oldFile);
+    QueueFile newQueue = openLarge(newFile);
+    while (!oldQueue.isEmpty()) {
+      newQueue.add(oldQueue.peek());
+      oldQueue.remove();
+    }
+    if (deleteWhenDone) oldFile.delete();
+    return newQueue;
+  }
+}

--- a/tape/src/main/java/com/squareup/tape/QueueFileImpl.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFileImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2010 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tape;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/**
+ * Legacy QueueFile implementation that can only support file sizes up to 2G
+ * and element count up to 2m.
+ * <p/>
+ * <p>Buffer file format:
+ * <pre>
+ *   Format:
+ *     Header              (16 bytes)
+ *     Element Ring Buffer (File Length - 16 bytes)
+ *
+ *   Header:
+ *     File Length            (4 bytes)
+ *     Element Count          (4 bytes)
+ *     First Element Position (4 bytes, =0 if null)
+ *     Last Element Position  (4 bytes, =0 if null)
+ *
+ *   Element:
+ *     Length (4 bytes)
+ *     Data   (Length bytes)
+ * </pre>
+ *
+ * @author Bob Lee (bob@squareup.com)
+ */
+public class QueueFileImpl extends AbstractQueueFile {
+
+  /**
+   * Length of header in bytes.
+   */
+  static final int HEADER_LENGTH = 16;
+
+  /**
+   * Constructs a new queue backed by the given file. Only one {@code QueueFile}
+   * instance should access a given file at a time.
+   */
+  public QueueFileImpl(File file) throws IOException {
+    super(file, HEADER_LENGTH);
+    readHeader();
+  }
+
+  /**
+   * For testing.
+   */
+  QueueFileImpl(RandomAccessFile raf) throws IOException {
+    super(raf, HEADER_LENGTH);
+    readHeader();
+  }
+
+  /**
+   * Reads the header.
+   */
+  private void readHeader() throws IOException {
+    raf.seek(0);
+    raf.readFully(buffer);
+    fileLength = readInt(buffer, 0);
+    if (fileLength > raf.length()) {
+      throw new IOException("File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
+    } else if (fileLength == 0) {
+      throw new IOException("File is corrupt; length stored in header is 0.");
+    }
+    elementCount = readInt(buffer, 4);
+    int firstOffset = readInt(buffer, 8);
+    int lastOffset = readInt(buffer, 12);
+    first = readElement(firstOffset);
+    last = readElement(lastOffset);
+  }
+
+  @Override
+  protected void writeHeader(long fileLength, long elementCount, long firstPosition, long lastPosition) throws IOException {
+    writeHeader(raf, fileLength, elementCount, firstPosition, lastPosition);
+  }
+
+  /**
+   * Writes header atomically. The arguments contain the updated values. The
+   * class member fields should not have changed yet. This only updates the
+   * state in the file. It's up to the caller to update the class member
+   * variables *after* this call succeeds. Assumes segment writes are atomic in
+   * the underlying file system.
+   */
+  @Override
+  protected void writeHeader(RandomAccessFile raf, long fileLength, long elementCount, long firstPosition, long lastPosition) throws IOException {
+    if (fileLength > Integer.MAX_VALUE) {
+      throw new IOException("file sizes larger than 2G is not supported");
+    }
+    if (elementCount > Integer.MAX_VALUE) {
+      throw new IOException("elementCount larger than 2m is not supported");
+    }
+    if (firstPosition >= Integer.MAX_VALUE) {
+      throw new IOException("firstPosition is invalid");
+    }
+    if (lastPosition >= Integer.MAX_VALUE) {
+      throw new IOException("lastPosition is invalid");
+    }
+    writeInts(buffer, (int) fileLength, (int) elementCount, (int) firstPosition, (int) lastPosition);
+    raf.seek(0);
+    raf.write(buffer);
+  }
+}

--- a/tape/src/main/java/com/squareup/tape/QueueFileImpl.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFileImpl.java
@@ -115,4 +115,9 @@ public class QueueFileImpl extends AbstractQueueFile {
     raf.seek(0);
     raf.write(buffer);
   }
+
+  @Override
+  protected long getMaxFileSize() {
+    return Integer.MAX_VALUE;
+  }
 }

--- a/tape/src/main/java/com/squareup/tape/TaskQueue.java
+++ b/tape/src/main/java/com/squareup/tape/TaskQueue.java
@@ -33,7 +33,7 @@ public class TaskQueue<T extends Task> implements ObjectQueue<T> {
     return task;
   }
 
-  @Override public int size() {
+  @Override public long size() {
     return delegate.size();
   }
 

--- a/tape/src/test/java/com/squareup/tape/BigQueueFileImplTest.java
+++ b/tape/src/test/java/com/squareup/tape/BigQueueFileImplTest.java
@@ -1,0 +1,78 @@
+package com.squareup.tape;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Tests for BigQueueFileImpl.
+ *
+ * @author Bob Lee (bob@squareup.com)
+ */
+@SuppressWarnings({"ResultOfMethodCallIgnored"})
+public class BigQueueFileImplTest extends AbstractQueueFileTest {
+
+  @Override
+  protected AbstractQueueFile getQueueFile(File file) throws IOException {
+    return new BigQueueFileImpl(file);
+  }
+
+  @Override
+  protected AbstractQueueFile getQueueFile(RandomAccessFile raf) throws IOException {
+    return new BigQueueFileImpl(raf);
+  }
+
+  @Override
+  protected int getHeaderLength() throws IOException {
+    return BigQueueFileImpl.HEADER_LENGTH;
+  }
+
+  /**
+   * Exercise a bug where an expanding queue file where the start and end positions
+   * are the same causes corruption.
+   */
+  @Test
+  public void testSaturatedFileExpansionMovesElements() throws IOException {
+    BigQueueFileImpl queue = new BigQueueFileImpl(file);
+
+    // Create test data - 1016-byte blocks marked consecutively 1, 2, 3, 4, 5 and 6,
+    // four of which perfectly fill the queue file, taking into account the file header
+    // and the item headers.
+    // Each item is of length
+    // (AbstractQueueFile.INITIAL_LENGTH - BigQueueFileImpl.HEADER_LENGTH) / 4 - element_header_length
+    // = 1008 bytes
+    byte[][] values = new byte[6][];
+    for (int blockNum = 0; blockNum < values.length; blockNum++) {
+      values[blockNum] = new byte[1008];
+      for (int i = 0; i < values[blockNum].length; i++) {
+        values[blockNum][i] = (byte) (blockNum + 1);
+      }
+    }
+
+    // Saturate the queue file
+    queue.add(values[0]);
+    queue.add(values[1]);
+    queue.add(values[2]);
+    queue.add(values[3]);
+
+    // Remove an element and add a new one so that the position of the start and
+    // end of the queue are equal
+    queue.remove();
+    queue.add(values[4]);
+
+    // Cause the queue file to expand
+    queue.add(values[5]);
+
+    // Make sure values are not corrupted
+    for (int i = 1; i < 6; i++) {
+      assertThat(queue.peek()).isEqualTo(values[i]);
+      queue.remove();
+    }
+
+    queue.close();
+  }
+}

--- a/tape/src/test/java/com/squareup/tape/BigQueueFileImplTest.java
+++ b/tape/src/test/java/com/squareup/tape/BigQueueFileImplTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for BigQueueFileImpl.
  *
- * @author Bob Lee (bob@squareup.com)
+ * @author Clement Pang (me@clementpang.com)
  */
 @SuppressWarnings({"ResultOfMethodCallIgnored"})
 public class BigQueueFileImplTest extends AbstractQueueFileTest {

--- a/tape/src/test/java/com/squareup/tape/QueueFileFactoryTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileFactoryTest.java
@@ -1,0 +1,86 @@
+package com.squareup.tape;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for QueueFileFactory.
+ *
+ * @author Clement Pang (me@clementpang.com)
+ */
+@SuppressWarnings({"ResultOfMethodCallIgnored"})
+public class QueueFileFactoryTest {
+
+  /**
+   * Takes up 33401 bytes in the queue (N*(N+1)/2+4*N). Picked 254 instead of
+   * 255 so that the number of bytes isn't a multiple of 4.
+   */
+  private static int N = 254;
+  private static byte[][] values = new byte[N][];
+
+  static {
+    for (int i = 0; i < N; i++) {
+      byte[] value = new byte[i];
+      // Example: values[3] = { 3, 2, 1 }
+      for (int ii = 0; ii < i; ii++) value[ii] = (byte) (i - ii);
+      values[i] = value;
+    }
+  }
+
+  private File file1;
+  private File file2;
+
+  @Before
+  public void setUp() throws Exception {
+    file1 = File.createTempFile("test.queue", null);
+    file1.delete();
+    file2 = File.createTempFile("test.queue", null);
+    file2.delete();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    file1.delete();
+    file2.delete();
+  }
+
+  @Test
+  public void testMigration() throws IOException {
+    QueueFile oldQueueFile = QueueFileFactory.open(file1);
+    for (int i = 0; i < N; i++) {
+      byte[] value = values[i];
+      oldQueueFile.add(value);
+    }
+    oldQueueFile.close();
+    QueueFile newQueueFile = QueueFileFactory.openAndMigrate(file1, file2, false);
+    for (int i = 0; i < N; i++) {
+      byte[] expected = values[i];
+      assertThat(newQueueFile.peek()).isEqualTo(expected);
+      newQueueFile.remove();
+    }
+    oldQueueFile = QueueFileFactory.open(file1);
+    assertTrue(oldQueueFile.isEmpty());
+    assertTrue(newQueueFile.isEmpty());
+
+    for (int i = 0; i < N; i++) {
+      byte[] value = values[i];
+      oldQueueFile.add(value);
+    }
+    newQueueFile = QueueFileFactory.openAndMigrate(file1, file2, true);
+    for (int i = 0; i < N; i++) {
+      byte[] expected = values[i];
+      assertThat(newQueueFile.peek()).isEqualTo(expected);
+      newQueueFile.remove();
+    }
+    assertFalse(file1.exists());
+    assertTrue(newQueueFile.isEmpty());
+  }
+}

--- a/tape/src/test/java/com/squareup/tape/QueueFileImplTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileImplTest.java
@@ -1,0 +1,78 @@
+// Copyright 2010 Square, Inc.
+package com.squareup.tape;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Tests for QueueFile.
+ *
+ * @author Bob Lee (bob@squareup.com)
+ */
+public class QueueFileImplTest extends AbstractQueueFileTest {
+
+  @Override
+  protected AbstractQueueFile getQueueFile(File file) throws IOException {
+    return new QueueFileImpl(file);
+  }
+
+  @Override
+  protected AbstractQueueFile getQueueFile(RandomAccessFile raf) throws IOException {
+    return new QueueFileImpl(raf);
+  }
+
+  @Override
+  protected int getHeaderLength() throws IOException {
+    return QueueFileImpl.HEADER_LENGTH;
+  }
+
+  /**
+   * Exercise a bug where an expanding queue file where the start and end positions
+   * are the same causes corruption.
+   */
+  @Test
+  public void testSaturatedFileExpansionMovesElements() throws IOException {
+    QueueFileImpl queue = new QueueFileImpl(file);
+
+    // Create test data - 1016-byte blocks marked consecutively 1, 2, 3, 4, 5 and 6,
+    // four of which perfectly fill the queue file, taking into account the file header
+    // and the item headers.
+    // Each item is of length
+    // (AbstractQueueFile.INITIAL_LENGTH - QueueFileImpl.HEADER_LENGTH) / 4 - element_header_length
+    // = 1016 bytes
+    byte[][] values = new byte[6][];
+    for (int blockNum = 0; blockNum < values.length; blockNum++) {
+      values[blockNum] = new byte[1016];
+      for (int i = 0; i < values[blockNum].length; i++) {
+        values[blockNum][i] = (byte) (blockNum + 1);
+      }
+    }
+
+    // Saturate the queue file
+    queue.add(values[0]);
+    queue.add(values[1]);
+    queue.add(values[2]);
+    queue.add(values[3]);
+
+    // Remove an element and add a new one so that the position of the start and
+    // end of the queue are equal
+    queue.remove();
+    queue.add(values[4]);
+
+    // Cause the queue file to expand
+    queue.add(values[5]);
+
+    // Make sure values are not corrupted
+    for (int i = 1; i < 6; i++) {
+      assertThat(queue.peek()).isEqualTo(values[i]);
+      queue.remove();
+    }
+
+    queue.close();
+  }
+}


### PR DESCRIPTION
Can't really reuse a lot of the code in the abstract class since ints and longs have to be taken care of separately. Migration function is provided.