### PR TITLE
fixed the count of bytes to transfer to the EOF on file expansion

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -380,7 +380,7 @@ public class QueueFile {
     if (endOfLastElement <= first.position) {
       FileChannel channel = raf.getChannel();
       channel.position(fileLength); // destination position
-      int count = endOfLastElement - Element.HEADER_LENGTH;
+      int count = endOfLastElement - HEADER_LENGTH;
       if (channel.transferTo(HEADER_LENGTH, count, channel) != count) {
         throw new AssertionError("Copied insufficient number of bytes!");
       }


### PR DESCRIPTION
The idea of this snippet is to make the buffer contiguous again. But `count` should not be `endOfLastElement - Element.HEADER_LENGTH` but `endOfLastElement - HEADER_LENGTH`.

I guess this was not detected before because it does not affect the behavior of the library, but still this is the correct way to do it.
