### PR TITLE
Add note regarding file system support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ an I/O exception is thrown during a mutating change, the change is aborted.
 for file systems that support atomic segment writes (like YAFFS). Most
 conventional file systems don't support this; if the power goes out while
 writing a segment, the segment will contain garbage and the file will be
-corrupt. We'll add journaling support so this class can be used with more
+corrupt. We'll add journaling support so `QueueFile` can be used with more
 file systems later.
 
 An `ObjectQueue` represents an ordering of arbitrary objects which can be backed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ synchronous; data will be written to disk before an operation returns. The
 underlying file is structured to survive process and even system crashes and if
 an I/O exception is thrown during a mutating change, the change is aborted.
 
+**NOTE:** The current implementation is built
+for file systems that support atomic segment writes (like YAFFS). Most
+conventional file systems don't support this; if the power goes out while
+writing a segment, the segment will contain garbage and the file will be
+corrupt. We'll add journaling support so this class can be used with more
+file systems later.
+
 An `ObjectQueue` represents an ordering of arbitrary objects which can be backed
 either by the filesystem (via `QueueFile`) or in memory only.
 


### PR DESCRIPTION
After an unclean termination of a service, QueueFile failed to peek and remove, yet the enqueue functionality continued to work.  I tweaked the header value for first element position to bypass the corrupt entry.  In looking at the code, I see comments making it quite clear this can happen, yet the README does not.

Is journaling, as noted in the comments, something on the roadmap?
