### PR TITLE
Add APIs to iterate over QueueFile

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,7 +50,7 @@ import static java.lang.Math.min;
  *
  * @author Bob Lee (bob@squareup.com)
  */
-public class QueueFile implements Closeable {
+public class QueueFile implements Closeable, Iterable<byte[]> {
   private static final Logger LOGGER = Logger.getLogger(QueueFile.class.getName());
 
   /** Initial file size in bytes. */
@@ -454,6 +456,68 @@ public class QueueFile implements Closeable {
       position = wrapPosition(current.position + Element.HEADER_LENGTH + current.length);
     }
     return elementCount;
+  }
+
+  @Override public Iterator<byte[]> iterator() {
+    return new ElementIterator();
+  }
+
+  private final class ElementIterator implements Iterator<byte[]> {
+    /** Index of element to be returned by subsequent call to next. */
+    private int cursor = 0;
+
+    /** Position of element to be returned by subsequent call to next. */
+    private int cursorPosition = first.position;
+
+    /**
+     * Size recorded at construction (also in remove) to stop iterator and also to check for
+     * concurrent modification.
+     */
+    private int size = elementCount;
+
+    @Override public boolean hasNext() {
+      return cursor != size;
+    }
+
+    private byte[] readNext() {
+      try {
+        // Read the current element
+        Element current = readElement(cursorPosition);
+        byte[] buffer = new byte[current.length];
+        cursorPosition = wrapPosition(current.position + Element.HEADER_LENGTH);
+        ringRead(cursorPosition, buffer, 0, current.length);
+
+        // Update the pointer to the next element
+        cursorPosition = wrapPosition(current.position + Element.HEADER_LENGTH + current.length);
+
+        // Return the read element
+        return buffer;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public byte[] next() {
+      if (cursor == size) throw new NoSuchElementException();
+
+      byte[] element = readNext();
+
+      if (elementCount != size) throw new ConcurrentModificationException();
+
+      cursor++;
+      return element;
+    }
+
+    @Override public void remove() {
+      try {
+        QueueFile.this.remove();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+
+      size = elementCount;
+      cursor--;
+    }
   }
 
   private final class ElementInputStream extends InputStream {

--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -475,6 +475,8 @@ public class QueueFile implements Closeable, Iterable<byte[]> {
      */
     private int size = elementCount;
 
+    private int lastElementIndex = 0;
+
     @Override public boolean hasNext() {
       return cursor != size;
     }
@@ -489,6 +491,8 @@ public class QueueFile implements Closeable, Iterable<byte[]> {
 
         // Update the pointer to the next element
         cursorPosition = wrapPosition(current.position + Element.HEADER_LENGTH + current.length);
+
+        lastElementIndex++;
 
         // Return the read element
         return buffer;
@@ -509,6 +513,12 @@ public class QueueFile implements Closeable, Iterable<byte[]> {
     }
 
     @Override public void remove() {
+      lastElementIndex--;
+      if (lastElementIndex != 0) {
+        throw new UnsupportedOperationException("This iterator can only remove "
+            + "elements at the head of the QueueFile.");
+      }
+
       try {
         QueueFile.this.remove();
       } catch (IOException e) {

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -141,7 +142,7 @@ import static org.fest.assertions.Fail.fail;
 
   @Test public void removeMultipleDoesNotCorrupt() throws IOException {
     QueueFile queue = new QueueFile(file);
-    for (int i = 0; i < 10; i ++) {
+    for (int i = 0; i < 10; i++) {
       queue.add(values[i]);
     }
 
@@ -319,6 +320,41 @@ import static org.fest.assertions.Fail.fail;
     queueFile.add(values[99]);
     queueFile.remove();
     assertThat(queueFile.peek()).isEqualTo(values[99]);
+  }
+
+  @Test public void testIterator() throws IOException {
+    QueueFile queueFile = new QueueFile(file);
+    queueFile.add(values[253]);
+
+    int saw = 0;
+    for (byte[] element : queueFile) {
+      assertThat(element).isEqualTo(values[253]);
+      saw++;
+    }
+    assertThat(saw).isEqualTo(1);
+
+    saw = 0;
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+
+    for (byte[] element : queueFile) {
+      assertThat(element).isEqualTo(values[253]);
+      saw++;
+    }
+    assertThat(saw).isEqualTo(6);
+
+    saw = 0;
+    Iterator<byte[]> iterator = queueFile.iterator();
+    while (iterator.hasNext()) {
+      byte[] element = iterator.next();
+      assertThat(element).isEqualTo(values[253]);
+      saw++;
+      iterator.remove();
+    }
+    assertThat(saw).isEqualTo(6);
   }
 
   @Test public void testFailedExpansion() throws IOException {

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -323,6 +323,7 @@ import static org.fest.assertions.Fail.fail;
   }
 
   @Test public void testIterator() throws IOException {
+    // todo: split these tests into their own methods
     QueueFile queueFile = new QueueFile(file);
     queueFile.add(values[253]);
 
@@ -355,6 +356,31 @@ import static org.fest.assertions.Fail.fail;
       iterator.remove();
     }
     assertThat(saw).isEqualTo(6);
+  }
+
+  @Test public void testIteratorOnlyRemovesFromHead() throws IOException {
+    QueueFile queueFile = new QueueFile(file);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+    queueFile.add(values[253]);
+
+    Iterator<byte[]> iterator = queueFile.iterator();
+    int saw = 0;
+    while (iterator.hasNext()) {
+      byte[] element = iterator.next();
+      saw++;
+      if (saw > 3) {
+        try {
+          iterator.remove();
+          fail("should not be able to remove elements at the middle of the queue.");
+        } catch (UnsupportedOperationException expected) {
+
+        }
+      }
+      assertThat(element).isEqualTo(values[253]);
+    }
   }
 
   @Test public void testFailedExpansion() throws IOException {


### PR DESCRIPTION
Just wanted to start a discussion around adding this to QueueFile for the next major release. Currently, I don't like that the `next` and `remove` methods hide the underlying `IOException`. This could be solved by wrapping it an object containing the stream and length as Jake suggested.