### PR TITLE
Throw exception for negative file length in header.

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -145,8 +145,9 @@ public class QueueFile implements Closeable {
     if (fileLength > raf.length()) {
       throw new IOException(
           "File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
-    } else if (fileLength == 0) {
-      throw new IOException("File is corrupt; length stored in header is 0.");
+    } else if (fileLength <= 0) {
+      throw new IOException(
+          "File is corrupt; length stored in header (" + fileLength + ") is invalid.");
     }
     elementCount = readInt(buffer, 4);
     int firstOffset = readInt(buffer, 8);

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -135,7 +135,24 @@ import static org.fest.assertions.Fail.fail;
       new QueueFile(file);
       fail("Should have complained about bad header length");
     } catch (IOException ex) {
-      assertThat(ex).hasMessage("File is corrupt; length stored in header is 0.");
+      assertThat(ex).hasMessage("File is corrupt; length stored in header (0) is invalid.");
+    }
+  }
+
+  @Test public void testNegativeSizeInHeaderComplains() throws IOException {
+    RandomAccessFile emptyFile = new RandomAccessFile(file, "rwd");
+    emptyFile.seek(0);
+    emptyFile.writeInt(-2147483648);
+    emptyFile.setLength(4096);
+    emptyFile.getChannel().force(true);
+    emptyFile.close();
+
+    try {
+      new QueueFile(file);
+      fail("Should have complained about bad header length");
+    } catch (IOException ex) {
+      assertThat(ex) //
+          .hasMessage("File is corrupt; length stored in header (-2147483648) is invalid.");
     }
   }
 


### PR DESCRIPTION
We're seeing cases where `RandomAccessFile#write((byte[] buffer, int byteOffset, int byteCount)` is being called with a negative `byteCount`.

```
java.lang.ArrayIndexOutOfBoundsException: length=4096; regionStart=0; regionLength=-1046
       at java.util.Arrays.checkOffsetAndCount(Arrays.java:1719)
       at libcore.io.IoBridge.write(IoBridge.java:491)
       at java.io.RandomAccessFile.write(RandomAccessFile.java:688)
       at com.segment.analytics.QueueFile.ringWrite(QueueFile.java:230)
       at com.segment.analytics.QueueFile.ringErase(QueueFile.java:239)
       at com.segment.analytics.QueueFile.remove(QueueFile.java:541)
       at com.segment.analytics.Segment.performFlush(Segment.java:151)
      ...
```

Looking at [`int beforeEof = fileLength - position;`](https://github.com/square/tape/blob/master/tape/src/main/java/com/squareup/tape/QueueFile.java#L228), this could happen when the fileLength is negative for some reason. This commit disallows a negative file length stored in the header during initialization.

Couldn't build locally due to this error : https://cloudup.com/c37tz2rjqGj. I'll update the PR in case the CI fails.