### PR TITLE
Make asList available on every ObjectQueue

### DIFF
--- a/tape/src/main/java/com/squareup/tape/FileObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/FileObjectQueue.java
@@ -88,7 +88,7 @@ public class FileObjectQueue<T> implements ObjectQueue<T> {
     }
   }
 
-  public List<T> asList() {
+  @Override public List<T> asList() {
     return peek(size());
   }
 

--- a/tape/src/main/java/com/squareup/tape/InMemoryObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/InMemoryObjectQueue.java
@@ -1,7 +1,10 @@
 // Copyright 2012 Square, Inc.
 package com.squareup.tape;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 
 /**
@@ -26,6 +29,10 @@ public class InMemoryObjectQueue<T> implements ObjectQueue<T> {
 
   @Override public T peek() {
     return tasks.peek();
+  }
+
+  @Override public List<T> asList() {
+    return Collections.unmodifiableList(new ArrayList<T>(tasks));
   }
 
   @Override public int size() {

--- a/tape/src/main/java/com/squareup/tape/ObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape/ObjectQueue.java
@@ -1,6 +1,8 @@
 // Copyright 2011 Square, Inc.
 package com.squareup.tape;
 
+import java.util.List;
+
 /**
  * A queue of objects.
  *
@@ -19,6 +21,11 @@ public interface ObjectQueue<T> {
    * queue.
    */
   T peek();
+
+  /**
+   * Returns the queue as a read-only {@link List}.
+   */
+  List<T> asList();
 
   /** Removes the head of the queue. */
   void remove();

--- a/tape/src/main/java/com/squareup/tape/TaskQueue.java
+++ b/tape/src/main/java/com/squareup/tape/TaskQueue.java
@@ -1,6 +1,8 @@
 // Copyright 2012 Square, Inc.
 package com.squareup.tape;
 
+import java.util.List;
+
 /**
  * Persistent task queue. Not safe for concurrent use.
  *
@@ -31,6 +33,10 @@ public class TaskQueue<T extends Task> implements ObjectQueue<T> {
       taskInjector.injectMembers(task);
     }
     return task;
+  }
+
+  @Override public List<T> asList() {
+    return delegate.asList();
   }
 
   @Override public int size() {


### PR DESCRIPTION
So that we don't have to rely on a specific queue implementation to read all entries.