### PR TITLE
Guard against concurrent modification if QueueFile is cleared during

### DIFF
--- a/tape/src/main/java/com/squareup/tape/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape/QueueFile.java
@@ -605,6 +605,7 @@ public class QueueFile implements Closeable, Iterable<byte[]> {
     last = Element.NULL;
     if (fileLength > INITIAL_LENGTH) setLength(INITIAL_LENGTH);
     fileLength = INITIAL_LENGTH;
+    modCount++;
   }
 
   /** Closes the underlying file. */

--- a/tape/src/test/java/com/squareup/tape/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape/QueueFileTest.java
@@ -739,6 +739,22 @@ import static org.junit.Assert.fail;
     }
   }
 
+  @Test public void testIteratorDisallowsConcurrentModificationWithClear() throws IOException {
+    QueueFile queueFile = new QueueFile(file);
+    for (int i = 0; i < 15; i++) {
+      queueFile.add(values[i]);
+    }
+
+    Iterator<byte[]> iterator = queueFile.iterator();
+    iterator.next();
+    queueFile.clear();
+    try {
+      iterator.hasNext();
+      fail();
+    } catch (ConcurrentModificationException ignored) {
+    }
+  }
+
   @Test public void testIteratorOnlyRemovesFromHead() throws IOException {
     QueueFile queueFile = new QueueFile(file);
     for (int i = 0; i < 15; i++) {


### PR DESCRIPTION
iteration.

Previously, calling `clear` during iteration would not throw a
`ConcurrentModificationException`.