### PR TITLE
Add QueueFile builder

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/FileObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape2/FileObjectQueue.java
@@ -12,18 +12,15 @@ final class FileObjectQueue<T> extends ObjectQueue<T> {
   private final QueueFile queueFile;
   /** Reusable byte output buffer. */
   private final DirectByteArrayOutputStream bytes = new DirectByteArrayOutputStream();
-  /** Keep file around for error reporting. */
-  private final File file;
-  @Private final Converter<T> converter;
+  private final Converter<T> converter;
 
-  FileObjectQueue(File file, Converter<T> converter) throws IOException {
-    this.file = file;
+  FileObjectQueue(QueueFile queueFile, Converter<T> converter) throws IOException {
+    this.queueFile = queueFile;
     this.converter = converter;
-    this.queueFile = new QueueFile(file);
   }
 
   @Override public File file() {
-    return file;
+    return queueFile.file();
   }
 
   @Override public int size() {

--- a/tape/src/main/java/com/squareup/tape2/ObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape2/ObjectQueue.java
@@ -13,8 +13,8 @@ import java.util.List;
 /** A queue of objects. */
 public abstract class ObjectQueue<T> implements Iterable<T>, Closeable {
   /** A queue for objects that are atomically and durably serialized to {@code file}. */
-  public static <T> ObjectQueue<T> create(File file, Converter<T> converter) throws IOException {
-    return new FileObjectQueue<T>(file, converter);
+  public static <T> ObjectQueue<T> create(QueueFile qf, Converter<T> converter) throws IOException {
+    return new FileObjectQueue<T>(qf, converter);
   }
 
   /**
@@ -60,7 +60,7 @@ public abstract class ObjectQueue<T> implements Iterable<T>, Closeable {
     return Collections.unmodifiableList(subList);
   }
 
-  /** Returns the entries in the queue as an unmodifiable {@link List}.*/
+  /** Returns the entries in the queue as an unmodifiable {@link List}. */
   public List<T> asList() throws IOException {
     return peek(size());
   }

--- a/tape/src/test/java/com/squareup/tape2/ObjectQueueTest.java
+++ b/tape/src/test/java/com/squareup/tape2/ObjectQueueTest.java
@@ -23,20 +23,21 @@ import static org.fest.assertions.Fail.fail;
 public class ObjectQueueTest {
   public enum QueueFactory {
     FILE() {
-      @Override public <T> ObjectQueue<T> create(File file, FileObjectQueue.Converter<T> converter)
+      @Override
+      public <T> ObjectQueue<T> create(QueueFile queueFile, FileObjectQueue.Converter<T> converter)
           throws IOException {
-        return ObjectQueue.create(file, converter);
+        return ObjectQueue.create(queueFile, converter);
       }
     },
     MEMORY() {
       @Override
-      public <T> ObjectQueue<T> create(File file, FileObjectQueue.Converter<T> converter) {
+      public <T> ObjectQueue<T> create(QueueFile file, FileObjectQueue.Converter<T> converter) {
         return ObjectQueue.createInMemory();
       }
     };
 
-    public abstract <T> ObjectQueue<T> create(File file, FileObjectQueue.Converter<T> converter)
-        throws IOException;
+    public abstract <T> ObjectQueue<T> create(QueueFile queueFile,
+        FileObjectQueue.Converter<T> converter) throws IOException;
   }
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
@@ -46,8 +47,9 @@ public class ObjectQueueTest {
   @Before public void setUp() throws IOException {
     File parent = folder.getRoot();
     File file = new File(parent, "object-queue");
+    QueueFile queueFile = new QueueFile.Builder(file).build();
 
-    queue = factory.create(file, new StringConverter());
+    queue = factory.create(queueFile, new StringConverter());
     queue.add("one");
     queue.add("two");
     queue.add("three");

--- a/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
@@ -31,33 +31,33 @@ public class QueueFileLoadingTest {
     testFile = File.createTempFile(FRESH_SERIALIZED_QUEUE, "test");
     assertTrue(testFile.delete());
     assertFalse(testFile.exists());
-    QueueFile queue = new QueueFile(testFile);
+    QueueFile queue = new QueueFile.Builder(testFile).build();
     assertEquals(0, queue.size());
     assertTrue(testFile.exists());
   }
 
   @Test public void testEmptyFileInitializes() throws Exception {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
-    QueueFile queue = new QueueFile(testFile);
+    QueueFile queue = new QueueFile.Builder(testFile).build();
     assertEquals(0, queue.size());
   }
 
   @Test public void testSingleEntryFileInitializes() throws Exception {
     testFile = copyTestFile(ONE_ENTRY_SERIALIZED_QUEUE);
-    QueueFile queue = new QueueFile(testFile);
+    QueueFile queue = new QueueFile.Builder(testFile).build();
     assertEquals(1, queue.size());
   }
 
   @Test(expected = IOException.class)
   public void testTruncatedEmptyFileThrows() throws Exception {
     testFile = copyTestFile(TRUNCATED_EMPTY_SERIALIZED_QUEUE);
-    new QueueFile(testFile);
+    new QueueFile.Builder(testFile).build();
   }
 
   @Test(expected = IOException.class)
   public void testTruncatedOneEntryFileThrows() throws Exception {
     testFile = copyTestFile(TRUNCATED_ONE_ENTRY_SERIALIZED_QUEUE);
-    new QueueFile(testFile);
+    new QueueFile.Builder(testFile).build();
   }
 
   @Test(expected = IOException.class)
@@ -67,16 +67,18 @@ public class QueueFileLoadingTest {
 
     File tmp = new UndeletableFile(testFile.getAbsolutePath());
     // Should throw an exception.
-    new QueueFile(tmp);
+    new QueueFile.Builder(testFile).build();
   }
 
   @Test(expected = IOException.class)
   public void testAddWithReadOnlyFile_missesMonitor() throws Exception {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
 
+    QueueFile qf = new QueueFile.Builder(testFile).build();
+
     // Should throw an exception.
-    FileObjectQueue<String> qf =
-        new FileObjectQueue<String>(testFile, new FileObjectQueue.Converter<String>() {
+    FileObjectQueue<String> queue =
+        new FileObjectQueue<String>(qf, new FileObjectQueue.Converter<String>() {
           @Override public String from(byte[] bytes) throws IOException {
             return null;
           }
@@ -87,6 +89,6 @@ public class QueueFileLoadingTest {
         });
 
     // Should throw an exception.
-    qf.add("trouble");
+    queue.add("trouble");
   }
 }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
@@ -78,12 +78,12 @@ public class QueueFileTest {
     return newQueueFile(true);
   }
 
-  private QueueFile newQueueFile(RandomAccessFile file) throws IOException {
-    return new QueueFile(file, true, forceLegacy);
+  private QueueFile newQueueFile(RandomAccessFile raf) throws IOException {
+    return new QueueFile(this.file, raf, true, forceLegacy);
   }
 
   private QueueFile newQueueFile(boolean zero) throws IOException {
-    return new QueueFile(file, zero, forceLegacy);
+    return new QueueFile.Builder(file).zero(zero).forceLegacy(forceLegacy).build();
   }
 
   @Before public void setUp() throws Exception {
@@ -258,7 +258,7 @@ public class QueueFileTest {
   }
 
   @Test public void removeZeroFromEmptyFileDoesNothing() throws IOException {
-    QueueFile queue = new QueueFile(file);
+    QueueFile queue = newQueueFile();
     queue.remove(0);
     assertThat(queue.isEmpty()).isTrue();
   }


### PR DESCRIPTION
Let's wait until we finish the v2 format changes so we can add options for those in the builder as well.

There's some awkwardness of using the builder with the ObjectQueue API. Either we 
1. Duplicate the builder for the file object queue.
2. Let users construct a QueueFile manually and pass it into the factory method `create(QueueFile queueFile, Converter<T> converter)`. This approach makes it awkward for keeping the raw file reference for error reporting.
