### PR TITLE
On file resize, only zero old memory chunks after header has been written

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -475,17 +475,14 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
 
     // Calculate the position of the tail end of the data in the ring buffer
     long endOfLastElement = wrapPosition(last.position + Element.HEADER_LENGTH + last.length);
-
+    long count = 0;
     // If the buffer is split, we need to make it contiguous
     if (endOfLastElement <= first.position) {
       FileChannel channel = raf.getChannel();
       channel.position(fileLength); // destination position
-      long count = endOfLastElement - headerLength;
+      count = endOfLastElement - headerLength;
       if (channel.transferTo(headerLength, count, channel) != count) {
         throw new AssertionError("Copied insufficient number of bytes!");
-      }
-      if (zero) {
-        ringErase(headerLength, count);
       }
     }
 
@@ -499,6 +496,10 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
     }
 
     fileLength = newLength;
+
+    if (zero) {
+      ringErase(headerLength, count);
+    }
   }
 
   /** Sets the length of the file. */


### PR DESCRIPTION
There is that very unlike corner case when things crash after the wrapped chunk has been moved to `oldFileLength`, but the header has not been updated yet, causing file corruption.

Zero-ing the old interval after the header has been written fixes this.