### PR TITLE
Add custom exception class to fix todo from #152

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/FileObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape2/FileObjectQueue.java
@@ -86,7 +86,7 @@ final class FileObjectQueue<T> extends ObjectQueue<T> {
       try {
         return converter.from(data);
       } catch (IOException e) {
-        throw new RuntimeException("todo: throw a proper error", e);
+        throw new TapeException("Error is occurred while converting object from binary form", e);
       }
     }
 

--- a/tape/src/main/java/com/squareup/tape2/InMemoryObjectQueue.java
+++ b/tape/src/main/java/com/squareup/tape2/InMemoryObjectQueue.java
@@ -109,7 +109,7 @@ final class InMemoryObjectQueue<T> extends ObjectQueue<T> {
       try {
         InMemoryObjectQueue.this.remove();
       } catch (IOException e) {
-        throw new RuntimeException("todo: throw a proper error", e);
+        throw new TapeException("Error is occurred while deleting object", e);
       }
 
       expectedModCount = modCount;

--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -557,7 +557,7 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
         // Return the read element.
         return buffer;
       } catch (IOException e) {
-        throw new RuntimeException("todo: throw a proper error", e);
+        throw new RuntimeException("Error is occurred while reading object", e);
       }
     }
 
@@ -572,7 +572,7 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
       try {
         QueueFile.this.remove();
       } catch (IOException e) {
-        throw new RuntimeException("todo: throw a proper error", e);
+        throw new TapeException("Error is occurred while deleting object", e);
       }
 
       expectedModCount = modCount;

--- a/tape/src/main/java/com/squareup/tape2/TapeException.java
+++ b/tape/src/main/java/com/squareup/tape2/TapeException.java
@@ -1,0 +1,10 @@
+package com.squareup.tape2;
+
+/** Thrown when an internal error has occurred in tape lib **/
+public class TapeException extends RuntimeException {
+
+    public TapeException(String message, Exception cause) {
+        super(message, cause);
+    }
+
+}

--- a/tape/src/main/java/com/squareup/tape2/TapeException.java
+++ b/tape/src/main/java/com/squareup/tape2/TapeException.java
@@ -3,6 +3,8 @@ package com.squareup.tape2;
 /** Thrown when an internal error has occurred in tape lib **/
 public class TapeException extends RuntimeException {
 
+    private static final long serialVersionUID = 5138225684096988531L;
+
     public TapeException(String message, Exception cause) {
         super(message, cause);
     }


### PR DESCRIPTION
This PR contains "todo" fixes from issue #152.
Custom exception type `TapeException` is introduced to wrap low-level `IOException`