### PR TITLE
Remove synthetic accessor method.

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -132,7 +132,7 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
 
   @Private boolean closed;
 
-  private static RandomAccessFile initializeFromFile(File file, boolean forceLegacy)
+  @Private static RandomAccessFile initializeFromFile(File file, boolean forceLegacy)
       throws IOException {
     if (!file.exists()) {
       // Use a temp file so we don't leave a partially-initialized file.


### PR DESCRIPTION
initializeFromFile is used in Builder.build().

Oops, I missed this one before.