### PR TITLE
File handle leak when exception in QueueFile construction

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -750,7 +750,20 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
      */
     public QueueFile build() throws IOException {
       RandomAccessFile raf = initializeFromFile(file, forceLegacy);
-      return new QueueFile(file, raf, zero, forceLegacy);
+
+      boolean succeeded = false;
+      try
+      {
+        QueueFile qf = new QueueFile(file, raf, zero, forceLegacy);
+        succeeded = true;
+        return qf;
+      }
+      finally
+      {
+        if (!succeeded) {
+          raf.close();
+        }
+      }
     }
   }
 }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
@@ -33,20 +33,41 @@ public final class QueueFileLoadingTest {
     assertTrue(testFile.delete());
     assertFalse(testFile.exists());
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(0, queue.size());
-    assertTrue(testFile.exists());
+    try
+    {
+      assertEquals(0, queue.size());
+      assertTrue(testFile.exists());
+    }
+    finally
+    {
+      queue.close();
+    }
   }
 
   @Test public void testEmptyFileInitializes() throws Exception {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(0, queue.size());
+    try
+    {
+      assertEquals(0, queue.size());
+    }
+    finally
+    {
+      queue.close();
+    }
   }
 
   @Test public void testSingleEntryFileInitializes() throws Exception {
     testFile = copyTestFile(ONE_ENTRY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(1, queue.size());
+    try
+    {
+      assertEquals( 1, queue.size() );
+    }
+    finally
+    {
+      queue.close();
+    }
   }
 
   @Test(expected = IOException.class)
@@ -88,8 +109,14 @@ public final class QueueFileLoadingTest {
             throw new IOException("fake Permission denied");
           }
         });
-
-    // Should throw an exception.
-    queue.add("trouble");
+    try
+    {
+      // Should throw an exception.
+      queue.add("trouble");
+    }
+    finally
+    {
+      queue.close();
+    }
   }
 }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
@@ -782,16 +782,23 @@ public class QueueFileTest {
 
     for (int i = 0; i < 10; i++) {
       QueueFile queueFile = newQueueFile();
-      for (int j = 0; j < i; j++) {
-        queueFile.add(data);
-      }
+      try
+      {
+        for (int j = 0; j < i; j++) {
+          queueFile.add(data);
+        }
 
-      int saw = 0;
-      for (byte[] element : queueFile) {
-        assertThat(element).isEqualTo(data);
-        saw++;
+        int saw = 0;
+        for (byte[] element : queueFile) {
+          assertThat(element).isEqualTo(data);
+          saw++;
+        }
+        assertThat(saw).isEqualTo(i);
       }
-      assertThat(saw).isEqualTo(i);
+      finally
+      {
+        queueFile.close();
+      }
       file.delete();
     }
   }


### PR DESCRIPTION
Fixed issue where a file handle was being leaked when an exception occurred during construction of QueueFile.

This issue was discovered when attempting to delete the file associated with the QueueFile. The file was locked and couldn't be deleted (this only occurs on Windows as Linux does not prevent deletion).

In the fix, if any exceptions occur during the construction of QueueFile, the random access file is closed before returning.