### PR TITLE
File handle leak when exception in QueueFile construction

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -750,7 +750,15 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
      */
     public QueueFile build() throws IOException {
       RandomAccessFile raf = initializeFromFile(file, forceLegacy);
-      return new QueueFile(file, raf, zero, forceLegacy);
+      QueueFile qf = null;
+      try {
+        qf = new QueueFile(file, raf, zero, forceLegacy);
+        return qf;
+      } finally {
+        if (qf == null) {
+          raf.close();
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixed issue where a file handle was being leaked when an exception occurred during construction of QueueFile.

This issue was discovered when attempting to delete the file associated
with the QueueFile. The file was locked and couldn't be deleted (this
only occurs on Windows as Linux does not prevent deletion).

In the fix, if any exceptions occur during the construction of
QueueFile, the random access file is closed before returning.