### PR TITLE
Unit test errors on Windows due to files being left open

### DIFF
--- a/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
@@ -34,8 +34,8 @@ public final class QueueFileLoadingTest {
     assertFalse(testFile.exists());
     QueueFile queue = new QueueFile.Builder(testFile).build();
     try {
-      assertEquals( 0, queue.size() );
-      assertTrue( testFile.exists() );
+      assertEquals(0, queue.size());
+      assertTrue(testFile.exists());
     } finally {
       queue.close();
     }
@@ -45,7 +45,7 @@ public final class QueueFileLoadingTest {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
     try {
-      assertEquals( 0, queue.size() );
+      assertEquals(0, queue.size());
     } finally {
       queue.close();
     }
@@ -55,7 +55,7 @@ public final class QueueFileLoadingTest {
     testFile = copyTestFile(ONE_ENTRY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
     try {
-      assertEquals( 1, queue.size() );
+      assertEquals(1, queue.size());
     } finally {
       queue.close();
     }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
@@ -33,32 +33,23 @@ public final class QueueFileLoadingTest {
     assertTrue(testFile.delete());
     assertFalse(testFile.exists());
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    try {
-      assertEquals(0, queue.size());
-      assertTrue(testFile.exists());
-    } finally {
-      queue.close();
-    }
+    assertEquals(0, queue.size());
+    assertTrue(testFile.exists());
+    queue.close();
   }
 
   @Test public void testEmptyFileInitializes() throws Exception {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    try {
-      assertEquals(0, queue.size());
-    } finally {
-      queue.close();
-    }
+    assertEquals(0, queue.size());
+    queue.close();
   }
 
   @Test public void testSingleEntryFileInitializes() throws Exception {
     testFile = copyTestFile(ONE_ENTRY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    try {
-      assertEquals(1, queue.size());
-    } finally {
-      queue.close();
-    }
+    assertEquals(1, queue.size());
+    queue.close();
   }
 
   @Test(expected = IOException.class)
@@ -101,9 +92,9 @@ public final class QueueFileLoadingTest {
           }
         });
 
+     // Should throw an exception.
      try {
-       // Should throw an exception.
-       queue.add("trouble");
+        queue.add("trouble");
      } finally {
        queue.close();
      }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileLoadingTest.java
@@ -33,20 +33,32 @@ public final class QueueFileLoadingTest {
     assertTrue(testFile.delete());
     assertFalse(testFile.exists());
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(0, queue.size());
-    assertTrue(testFile.exists());
+    try {
+      assertEquals( 0, queue.size() );
+      assertTrue( testFile.exists() );
+    } finally {
+      queue.close();
+    }
   }
 
   @Test public void testEmptyFileInitializes() throws Exception {
     testFile = copyTestFile(EMPTY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(0, queue.size());
+    try {
+      assertEquals( 0, queue.size() );
+    } finally {
+      queue.close();
+    }
   }
 
   @Test public void testSingleEntryFileInitializes() throws Exception {
     testFile = copyTestFile(ONE_ENTRY_SERIALIZED_QUEUE);
     QueueFile queue = new QueueFile.Builder(testFile).build();
-    assertEquals(1, queue.size());
+    try {
+      assertEquals( 1, queue.size() );
+    } finally {
+      queue.close();
+    }
   }
 
   @Test(expected = IOException.class)
@@ -89,7 +101,11 @@ public final class QueueFileLoadingTest {
           }
         });
 
-    // Should throw an exception.
-    queue.add("trouble");
+     try {
+       // Should throw an exception.
+       queue.add("trouble");
+     } finally {
+       queue.close();
+     }
   }
 }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
@@ -783,16 +783,16 @@ public class QueueFileTest {
     for (int i = 0; i < 10; i++) {
       QueueFile queueFile = newQueueFile();
       try {
-        for( int j = 0; j < i; j++ ) {
-          queueFile.add( data );
+        for (int j = 0; j < i; j++) {
+          queueFile.add(data);
         }
 
         int saw = 0;
-        for( byte[] element : queueFile ) {
-          assertThat( element ).isEqualTo( data );
+        for (byte[] element : queueFile) {
+          assertThat(element).isEqualTo(data);
           saw++;
         }
-        assertThat( saw ).isEqualTo( i );
+        assertThat(saw).isEqualTo(i);
       } finally {
         queueFile.close();
       }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
@@ -782,16 +782,20 @@ public class QueueFileTest {
 
     for (int i = 0; i < 10; i++) {
       QueueFile queueFile = newQueueFile();
-      for (int j = 0; j < i; j++) {
-        queueFile.add(data);
-      }
+      try {
+        for( int j = 0; j < i; j++ ) {
+          queueFile.add( data );
+        }
 
-      int saw = 0;
-      for (byte[] element : queueFile) {
-        assertThat(element).isEqualTo(data);
-        saw++;
+        int saw = 0;
+        for( byte[] element : queueFile ) {
+          assertThat( element ).isEqualTo( data );
+          saw++;
+        }
+        assertThat( saw ).isEqualTo( i );
+      } finally {
+        queueFile.close();
       }
-      assertThat(saw).isEqualTo(i);
       file.delete();
     }
   }

--- a/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
+++ b/tape/src/test/java/com/squareup/tape2/QueueFileTest.java
@@ -782,20 +782,17 @@ public class QueueFileTest {
 
     for (int i = 0; i < 10; i++) {
       QueueFile queueFile = newQueueFile();
-      try {
-        for (int j = 0; j < i; j++) {
-          queueFile.add(data);
-        }
-
-        int saw = 0;
-        for (byte[] element : queueFile) {
-          assertThat(element).isEqualTo(data);
-          saw++;
-        }
-        assertThat(saw).isEqualTo(i);
-      } finally {
-        queueFile.close();
+      for (int j = 0; j < i; j++) {
+        queueFile.add(data);
       }
+
+      int saw = 0;
+      for (byte[] element : queueFile) {
+        assertThat(element).isEqualTo(data);
+        saw++;
+      }
+      assertThat(saw).isEqualTo(i);
+      queueFile.close();
       file.delete();
     }
   }


### PR DESCRIPTION
Added close calls to tests where files were being left open. This resulted in test case errors on Windows when files were deleted in cleanup (Did not occur on Linux).

Closes #177.