### PR TITLE
Split transfer data because of the size limit of FileChannelImpl

### DIFF
--- a/tape/build.gradle
+++ b/tape/build.gradle
@@ -18,4 +18,8 @@ checkstyle {
   toolVersion = '7.7'
 }
 
+test {
+  maxHeapSize = '4G' // maximum heap size
+}
+
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
### What changes 
- Split the data that need to transfer into pieces with a maximum size `Integer.MAX_VALUE`
- Add a unit test to cover the case of transferring large data (more than 2GB)

### Why needs these changes
In the underlying `FileChannelImpl`, it can transfer at most 2 GB data at a time, which will cause an error if we transfer more than 2 GB data directly:
https://github.com/square/tape/blob/445cd3fd0a7b3ec48c9ea3e0e86663fe6d3735d8/tape/src/main/java/com/squareup/tape2/QueueFile.java#L462-L464